### PR TITLE
Don't set basic auth if an Authorization header is already present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,16 @@ func main() {
   }
 }
 ```
+
+## OAuth
+
+```go
+func main() {
+  t := &oauth.Transport{
+    Token:     &oauth.Token{AccessToken: token},
+    Transport: heroku.DefaultTransport,
+  }
+
+  h := heroku.NewService(t.Client())
+}
+```

--- a/v3/transport.go
+++ b/v3/transport.go
@@ -53,7 +53,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	req.Header.Set("Accept", "application/vnd.heroku+json; version=3")
 	req.Header.Set("Request-Id", uuid.New())
-	req.SetBasicAuth(t.Username, t.Password)
+	if req.Header.Get("Authorization") == "" {
+		req.SetBasicAuth(t.Username, t.Password)
+	}
 	for k, v := range t.AdditionalHeaders {
 		req.Header[k] = v
 	}


### PR DESCRIPTION
This makes it possible to use this transport in combination with [goauth2](https://code.google.com/p/goauth2/source/browse/oauth/oauth.go). Previously `req.SetBasicAuth` would override the `Authorization` header set by the oauth2 transport.
