### PR TITLE
Remove os.stdErr from log.Println

### DIFF
--- a/v3/transport.go
+++ b/v3/transport.go
@@ -114,7 +114,7 @@ func checkResponse(resp *http.Response) error {
 		return Error{error: errors.New(e.Message), ID: e.ID, URL: e.URL}
 	}
 	if msg := resp.Header.Get("X-Heroku-Warning"); msg != "" {
-		log.Println(os.Stderr, strings.TrimSpace(msg))
+		log.Println(strings.TrimSpace(msg))
 	}
 	return nil
 }


### PR DESCRIPTION
log.Println does not accept a Writer as a first argument (unlike fmt.Fprintln), 
so ends up printing the os.stdErr object reference. The standard logger goes
to stdErr by default, so removing this argument.
