### PR TITLE
Close http.Response.Body on err in Transport

### DIFF
--- a/v3/transport.go
+++ b/v3/transport.go
@@ -74,6 +74,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	resp, err := t.Transport.RoundTrip(req)
 	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return nil, err
 	}
 
@@ -88,6 +91,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if err = checkResponse(resp); err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
`Transport.RoundTrip` returns a `nil` `http.Response` on errors
without first closing the `Body`. This violates the contract
with `http.Response` and can leave open sockets until the
process exits.
