### PR TITLE
Forward CancelRequest to underlying Transport

### DIFF
--- a/v3/transport.go
+++ b/v3/transport.go
@@ -42,6 +42,19 @@ type Transport struct {
 	Transport http.RoundTripper
 }
 
+// Forward CancelRequest to underlying Transport
+func (t *Transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	tr, ok := t.Transport.(canceler)
+	if !ok {
+		log.Printf("heroku: Client Transport of type %T doesn't support CancelRequest; Timeout not supported\n", t.Transport)
+		return
+	}
+	tr.CancelRequest(req)
+}
+
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.Transport == nil {
 		t.Transport = http.DefaultTransport


### PR DESCRIPTION
`http.Client.doFollowingRedirects` only support timeouts if the `http.Transport` is a `canceler`. Even though the underlying `http.DefaultTransport` is a `canceler`, `heroku.Transport` is not, so requests never get cancelled when a timeout is set on `http.Clint`. This change forwards the `CancelRequest` to underlying transport if it is a `canceler`.
