### PR TITLE
Emit ; in Range header when sorting without FirstID/LastID

### DIFF
--- a/v3/heroku.go
+++ b/v3/heroku.go
@@ -153,9 +153,11 @@ func (lr *ListRange) SetHeader(req *http.Request) {
 		if lr.Descending {
 			hdrval += ", "
 		}
+	} else if lr.Descending {
+		hdrval += "; "
 	}
 	if lr.Descending {
-		hdrval += ", order=desc"
+		hdrval += "order=desc"
 	}
 	req.Header.Set("Range", hdrval)
 	return


### PR DESCRIPTION
Previously, this:

```
h.ReleaseList("myapp",
        &heroku.ListRange{Field: "version", Descending: true})
```

would generate the header:

```
Range: version .., order=desc
```

and yield an error:

```
{"id":"requested_range_not_satisfiable","message":"End range bounds without a start bound are currently not supported. Please specify a start bound. "}
```

With the fix, it generates:

```
Range: version ..; order=desc
```

which seems to be [what the API expects](https://devcenter.heroku.com/articles/platform-api-reference#ranges).

Just started writing Go today, I bet there's a better way to structure the fix. Lemme know!
