### PR TITLE
Regenerate client based on new schema

### DIFF
--- a/v3/heroku.go
+++ b/v3/heroku.go
@@ -15,17 +15,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"io"
 	"net/http"
 	"reflect"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/google/go-querystring/query"
 )
 
 const (
-	Version          = ""
+	Version          = "v3"
 	DefaultUserAgent = "heroku/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 	DefaultURL       = "https://api.heroku.com"
 )

--- a/v3/heroku.go
+++ b/v3/heroku.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	Version          = "v3"
+	Version          = ""
 	DefaultUserAgent = "heroku/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 	DefaultURL       = "https://api.heroku.com"
 )
@@ -260,17 +260,43 @@ func (s *Service) AccountDelete(ctx context.Context) (*Account, error) {
 	return &account, s.Delete(ctx, &account, fmt.Sprintf("/account"))
 }
 
+// Info for account.
+func (s *Service) AccountInfoByUser(ctx context.Context, accountIdentity string) (*Account, error) {
+	var account Account
+	return &account, s.Get(ctx, &account, fmt.Sprintf("/users/%v", accountIdentity), nil, nil)
+}
+
+type AccountUpdateByUserOpts struct {
+	AllowTracking *bool   `json:"allow_tracking,omitempty" url:"allow_tracking,omitempty,key"` // whether to allow third party web activity tracking
+	Beta          *bool   `json:"beta,omitempty" url:"beta,omitempty,key"`                     // whether allowed to utilize beta Heroku features
+	Name          *string `json:"name,omitempty" url:"name,omitempty,key"`                     // full name of the account owner
+}
+
+// Update account.
+func (s *Service) AccountUpdateByUser(ctx context.Context, accountIdentity string, o AccountUpdateByUserOpts) (*Account, error) {
+	var account Account
+	return &account, s.Patch(ctx, &account, fmt.Sprintf("/users/%v", accountIdentity), o)
+}
+
+// Delete account. Note that this action cannot be undone.
+func (s *Service) AccountDeleteByUser(ctx context.Context, accountIdentity string) (*Account, error) {
+	var account Account
+	return &account, s.Delete(ctx, &account, fmt.Sprintf("/users/%v", accountIdentity))
+}
+
 // An account feature represents a Heroku labs capability that can be
 // enabled or disabled for an account on Heroku.
 type AccountFeature struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
+	CreatedAt     time.Time `json:"created_at" url:"created_at,key"`         // when account feature was created
+	Description   string    `json:"description" url:"description,key"`       // description of account feature
+	DisplayName   string    `json:"display_name" url:"display_name,key"`     // user readable feature name
+	DocURL        string    `json:"doc_url" url:"doc_url,key"`               // documentation URL of account feature
+	Enabled       bool      `json:"enabled" url:"enabled,key"`               // whether or not account feature has been enabled
+	FeedbackEmail string    `json:"feedback_email" url:"feedback_email,key"` // e-mail to send feedback about the feature
+	ID            string    `json:"id" url:"id,key"`                         // unique identifier of account feature
+	Name          string    `json:"name" url:"name,key"`                     // unique name of account feature
+	State         string    `json:"state" url:"state,key"`                   // state of account feature
+	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`         // when account feature was updated
 }
 
 // Info for an existing account feature.
@@ -322,6 +348,20 @@ type AddOn struct {
 	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
 	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
 }
+type AddOnListResult []AddOn
+
+// List all existing add-ons.
+func (s *Service) AddOnList(ctx context.Context, lr *ListRange) (AddOnListResult, error) {
+	var addOn AddOnListResult
+	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/addons"), nil, lr)
+}
+
+// Info for an existing add-on.
+func (s *Service) AddOnInfo(ctx context.Context, addOnIdentity string) (*AddOn, error) {
+	var addOn AddOn
+	return &addOn, s.Get(ctx, &addOn, fmt.Sprintf("/addons/%v", addOnIdentity), nil, nil)
+}
+
 type AddOnCreateOpts struct {
 	Attachment *struct{}          `json:"attachment,omitempty" url:"attachment,omitempty,key"` // name for add-on's initial attachment
 	Config     *map[string]string `json:"config,omitempty" url:"config,omitempty,key"`         // custom add-on provisioning options
@@ -341,25 +381,9 @@ func (s *Service) AddOnDelete(ctx context.Context, appIdentity string, addOnIden
 }
 
 // Info for an existing add-on.
-func (s *Service) AddOnInfo(ctx context.Context, appIdentity string, addOnIdentity string) (*AddOn, error) {
+func (s *Service) AddOnInfoByApp(ctx context.Context, appIdentity string, addOnIdentity string) (*AddOn, error) {
 	var addOn AddOn
 	return &addOn, s.Get(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity), nil, nil)
-}
-
-type AddOnListResult []AddOn
-
-// List all existing add-ons.
-func (s *Service) AddOnList(ctx context.Context, lr *ListRange) (AddOnListResult, error) {
-	var addOn AddOnListResult
-	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/addons"), nil, lr)
-}
-
-type AddOnListByUserResult []AddOn
-
-// List all existing add-ons a user has access to
-func (s *Service) AddOnListByUser(ctx context.Context, accountIdentity string, lr *ListRange) (AddOnListByUserResult, error) {
-	var addOn AddOnListByUserResult
-	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/users/%v/addons", accountIdentity), nil, lr)
 }
 
 type AddOnListByAppResult []AddOn
@@ -381,12 +405,28 @@ func (s *Service) AddOnUpdate(ctx context.Context, appIdentity string, addOnIden
 	return &addOn, s.Patch(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity), o)
 }
 
+type AddOnListByUserResult []AddOn
+
+// List all existing add-ons a user has access to
+func (s *Service) AddOnListByUser(ctx context.Context, accountIdentity string, lr *ListRange) (AddOnListByUserResult, error) {
+	var addOn AddOnListByUserResult
+	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/users/%v/addons", accountIdentity), nil, lr)
+}
+
+type AddOnListByTeamResult []AddOn
+
+// List add-ons used across all Team apps
+func (s *Service) AddOnListByTeam(ctx context.Context, teamIdentity string, lr *ListRange) (AddOnListByTeamResult, error) {
+	var addOn AddOnListByTeamResult
+	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/teams/%v/addons", teamIdentity), nil, lr)
+}
+
 // Add-on Actions are lifecycle operations for add-on provisioning and
 // deprovisioning. They allow whitelisted add-on providers to
 // (de)provision add-ons in the background and then report back when
 // (de)provisioning is complete.
 type AddOnAction struct{}
-type AddOnActionCreateProvisionResult struct {
+type AddOnActionProvisionResult struct {
 	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
 	AddonService struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
@@ -411,12 +451,12 @@ type AddOnActionCreateProvisionResult struct {
 }
 
 // Mark an add-on as provisioned for use.
-func (s *Service) AddOnActionCreateProvision(ctx context.Context, addOnIdentity string) (*AddOnActionCreateProvisionResult, error) {
-	var addOnAction AddOnActionCreateProvisionResult
+func (s *Service) AddOnActionProvision(ctx context.Context, addOnIdentity string) (*AddOnActionProvisionResult, error) {
+	var addOnAction AddOnActionProvisionResult
 	return &addOnAction, s.Post(ctx, &addOnAction, fmt.Sprintf("/addons/%v/actions/provision", addOnIdentity), nil)
 }
 
-type AddOnActionCreateDeprovisionResult struct {
+type AddOnActionDeprovisionResult struct {
 	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
 	AddonService struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
@@ -441,8 +481,8 @@ type AddOnActionCreateDeprovisionResult struct {
 }
 
 // Mark an add-on as deprovisioned.
-func (s *Service) AddOnActionCreateDeprovision(ctx context.Context, addOnIdentity string) (*AddOnActionCreateDeprovisionResult, error) {
-	var addOnAction AddOnActionCreateDeprovisionResult
+func (s *Service) AddOnActionDeprovision(ctx context.Context, addOnIdentity string) (*AddOnActionDeprovisionResult, error) {
+	var addOnAction AddOnActionDeprovisionResult
 	return &addOnAction, s.Post(ctx, &addOnAction, fmt.Sprintf("/addons/%v/actions/deprovision", addOnIdentity), nil)
 }
 
@@ -468,6 +508,7 @@ type AddOnAttachment struct {
 	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
 	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
 	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	Namespace *string   `json:"namespace" url:"namespace,key"`   // attachment namespace
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
 	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
 }
@@ -476,7 +517,8 @@ type AddOnAttachmentCreateOpts struct {
 	App   string `json:"app" url:"app,key"`                         // unique identifier of app
 	Force *bool  `json:"force,omitempty" url:"force,omitempty,key"` // whether or not to allow existing attachment with same name to be
 	// replaced
-	Name *string `json:"name,omitempty" url:"name,omitempty,key"` // unique name for this add-on attachment to this app
+	Name      *string `json:"name,omitempty" url:"name,omitempty,key"`           // unique name for this add-on attachment to this app
+	Namespace *string `json:"namespace,omitempty" url:"namespace,omitempty,key"` // attachment namespace
 }
 
 // Create a new add-on attachment.
@@ -619,6 +661,14 @@ func (s *Service) AddOnRegionCapabilityListByAddOnService(ctx context.Context, a
 	return addOnRegionCapability, s.Get(ctx, &addOnRegionCapability, fmt.Sprintf("/addon-services/%v/region-capabilities", addOnServiceIdentity), nil, lr)
 }
 
+type AddOnRegionCapabilityListByRegionResult []AddOnRegionCapability
+
+// List existing add-on region capabilities for a region.
+func (s *Service) AddOnRegionCapabilityListByRegion(ctx context.Context, regionIdentity string, lr *ListRange) (AddOnRegionCapabilityListByRegionResult, error) {
+	var addOnRegionCapability AddOnRegionCapabilityListByRegionResult
+	return addOnRegionCapability, s.Get(ctx, &addOnRegionCapability, fmt.Sprintf("/regions/%v/addon-region-capabilities", regionIdentity), nil, lr)
+}
+
 // Add-on services represent add-ons that may be provisioned for apps.
 // Endpoints under add-on services can be accessed without
 // authentication.
@@ -688,6 +738,10 @@ type App struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
 		Name string `json:"name" url:"name,key"` // unique name of stack
 	} `json:"stack" url:"stack,key"` // identity of app stack
+	Team *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of team
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // identity of team
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
 	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
@@ -725,7 +779,7 @@ func (s *Service) AppList(ctx context.Context, lr *ListRange) (AppListResult, er
 
 type AppListOwnedAndCollaboratedResult []App
 
-// List owned and collaborated apps (excludes organization apps).
+// List owned and collaborated apps (excludes team apps).
 func (s *Service) AppListOwnedAndCollaborated(ctx context.Context, accountIdentity string, lr *ListRange) (AppListOwnedAndCollaboratedResult, error) {
 	var app AppListOwnedAndCollaboratedResult
 	return app, s.Get(ctx, &app, fmt.Sprintf("/users/%v/apps", accountIdentity), nil, lr)
@@ -746,14 +800,16 @@ func (s *Service) AppUpdate(ctx context.Context, appIdentity string, o AppUpdate
 // An app feature represents a Heroku labs capability that can be
 // enabled or disabled for an app on Heroku.
 type AppFeature struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
-	Description string    `json:"description" url:"description,key"` // description of app feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
-	State       string    `json:"state" url:"state,key"`             // state of app feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
+	CreatedAt     time.Time `json:"created_at" url:"created_at,key"`         // when app feature was created
+	Description   string    `json:"description" url:"description,key"`       // description of app feature
+	DisplayName   string    `json:"display_name" url:"display_name,key"`     // user readable feature name
+	DocURL        string    `json:"doc_url" url:"doc_url,key"`               // documentation URL of app feature
+	Enabled       bool      `json:"enabled" url:"enabled,key"`               // whether or not app feature has been enabled
+	FeedbackEmail string    `json:"feedback_email" url:"feedback_email,key"` // e-mail to send feedback about the feature
+	ID            string    `json:"id" url:"id,key"`                         // unique identifier of app feature
+	Name          string    `json:"name" url:"name,key"`                     // unique name of app feature
+	State         string    `json:"state" url:"state,key"`                   // state of app feature
+	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`         // when app feature was updated
 }
 
 // Info for an existing app feature.
@@ -1064,7 +1120,7 @@ type Collaborator struct {
 		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
 		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
 	} `json:"permissions" url:"permissions,key"`
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	Role      *string   `json:"role" url:"role,key"`             // role in the team
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
 	User      struct {
 		Email     string `json:"email" url:"email,key"`         // unique email address of account
@@ -1398,13 +1454,10 @@ type FilterAppsAppsResult []struct {
 	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
 	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
 	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
 	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
 	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this app
-	Owner *struct {
+	Owner                        *struct {
 		Email string `json:"email" url:"email,key"` // unique email address of account
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
 	} `json:"owner" url:"owner,key"` // identity of app owner
@@ -1423,6 +1476,9 @@ type FilterAppsAppsResult []struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
 		Name string `json:"name" url:"name,key"` // unique name of stack
 	} `json:"stack" url:"stack,key"` // identity of app stack
+	Team *struct {
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // team that owns this app
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
 	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
@@ -1508,15 +1564,15 @@ type IdentityProvider struct {
 	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
 	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
 }
-type IdentityProviderListResult []IdentityProvider
+type IdentityProviderListByOrganizationResult []IdentityProvider
 
 // Get a list of an organization's Identity Providers
-func (s *Service) IdentityProviderList(ctx context.Context, organizationName string, lr *ListRange) (IdentityProviderListResult, error) {
-	var identityProvider IdentityProviderListResult
+func (s *Service) IdentityProviderListByOrganization(ctx context.Context, organizationName string, lr *ListRange) (IdentityProviderListByOrganizationResult, error) {
+	var identityProvider IdentityProviderListByOrganizationResult
 	return identityProvider, s.Get(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers", organizationName), nil, lr)
 }
 
-type IdentityProviderCreateOpts struct {
+type IdentityProviderCreateByOrganizationOpts struct {
 	Certificate  string  `json:"certificate" url:"certificate,key"`                           // raw contents of the public certificate (eg: .crt or .pem file)
 	EntityID     string  `json:"entity_id" url:"entity_id,key"`                               // URL identifier provided by the identity provider
 	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
@@ -1524,12 +1580,12 @@ type IdentityProviderCreateOpts struct {
 }
 
 // Create an Identity Provider for an organization
-func (s *Service) IdentityProviderCreate(ctx context.Context, organizationName string, o IdentityProviderCreateOpts) (*IdentityProvider, error) {
+func (s *Service) IdentityProviderCreateByOrganization(ctx context.Context, organizationName string, o IdentityProviderCreateByOrganizationOpts) (*IdentityProvider, error) {
 	var identityProvider IdentityProvider
 	return &identityProvider, s.Post(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers", organizationName), o)
 }
 
-type IdentityProviderUpdateOpts struct {
+type IdentityProviderUpdateByOrganizationOpts struct {
 	Certificate  *string `json:"certificate,omitempty" url:"certificate,omitempty,key"`       // raw contents of the public certificate (eg: .crt or .pem file)
 	EntityID     *string `json:"entity_id,omitempty" url:"entity_id,omitempty,key"`           // URL identifier provided by the identity provider
 	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
@@ -1537,15 +1593,55 @@ type IdentityProviderUpdateOpts struct {
 }
 
 // Update an organization's Identity Provider
-func (s *Service) IdentityProviderUpdate(ctx context.Context, organizationName string, identityProviderID string, o IdentityProviderUpdateOpts) (*IdentityProvider, error) {
+func (s *Service) IdentityProviderUpdateByOrganization(ctx context.Context, organizationName string, identityProviderID string, o IdentityProviderUpdateByOrganizationOpts) (*IdentityProvider, error) {
 	var identityProvider IdentityProvider
 	return &identityProvider, s.Patch(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers/%v", organizationName, identityProviderID), o)
 }
 
 // Delete an organization's Identity Provider
-func (s *Service) IdentityProviderDelete(ctx context.Context, organizationName string, identityProviderID string) (*IdentityProvider, error) {
+func (s *Service) IdentityProviderDeleteByOrganization(ctx context.Context, organizationName string, identityProviderID string) (*IdentityProvider, error) {
 	var identityProvider IdentityProvider
 	return &identityProvider, s.Delete(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers/%v", organizationName, identityProviderID))
+}
+
+type IdentityProviderListByTeamResult []IdentityProvider
+
+// Get a list of a team's Identity Providers
+func (s *Service) IdentityProviderListByTeam(ctx context.Context, teamIdentity string, lr *ListRange) (IdentityProviderListByTeamResult, error) {
+	var identityProvider IdentityProviderListByTeamResult
+	return identityProvider, s.Get(ctx, &identityProvider, fmt.Sprintf("/teams/%v/identity-providers", teamIdentity), nil, lr)
+}
+
+type IdentityProviderCreateByTeamOpts struct {
+	Certificate  string  `json:"certificate" url:"certificate,key"`                           // raw contents of the public certificate (eg: .crt or .pem file)
+	EntityID     string  `json:"entity_id" url:"entity_id,key"`                               // URL identifier provided by the identity provider
+	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
+	SsoTargetURL string  `json:"sso_target_url" url:"sso_target_url,key"`                     // single sign on URL for this identity provider
+}
+
+// Create an Identity Provider for a team
+func (s *Service) IdentityProviderCreateByTeam(ctx context.Context, teamIdentity string, o IdentityProviderCreateByTeamOpts) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
+	return &identityProvider, s.Post(ctx, &identityProvider, fmt.Sprintf("/teams/%v/identity-providers", teamIdentity), o)
+}
+
+type IdentityProviderUpdateByTeamOpts struct {
+	Certificate  *string `json:"certificate,omitempty" url:"certificate,omitempty,key"`       // raw contents of the public certificate (eg: .crt or .pem file)
+	EntityID     *string `json:"entity_id,omitempty" url:"entity_id,omitempty,key"`           // URL identifier provided by the identity provider
+	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
+	SsoTargetURL *string `json:"sso_target_url,omitempty" url:"sso_target_url,omitempty,key"` // single sign on URL for this identity provider
+}
+
+// Update a team's Identity Provider
+func (s *Service) IdentityProviderUpdateByTeam(ctx context.Context, teamIdentity string, identityProviderID string, o IdentityProviderUpdateByTeamOpts) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
+	return &identityProvider, s.Patch(ctx, &identityProvider, fmt.Sprintf("/teams/%v/identity-providers/%v", teamIdentity, identityProviderID), o)
+}
+
+// Delete a team's Identity Provider
+func (s *Service) IdentityProviderDeleteByTeam(ctx context.Context, teamName string, identityProviderID string) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
+	return &identityProvider, s.Delete(ctx, &identityProvider, fmt.Sprintf("/teams/%v/identity-providers/%v", teamName, identityProviderID))
 }
 
 // An inbound-ruleset is a collection of rules that specify what hosts
@@ -1561,9 +1657,15 @@ type InboundRuleset struct {
 }
 
 // Current inbound ruleset for a space
-func (s *Service) InboundRulesetInfo(ctx context.Context, spaceIdentity string) (*InboundRuleset, error) {
+func (s *Service) InboundRulesetCurrent(ctx context.Context, spaceIdentity string) (*InboundRuleset, error) {
 	var inboundRuleset InboundRuleset
 	return &inboundRuleset, s.Get(ctx, &inboundRuleset, fmt.Sprintf("/spaces/%v/inbound-ruleset", spaceIdentity), nil, nil)
+}
+
+// Info on an existing Inbound Ruleset
+func (s *Service) InboundRulesetInfo(ctx context.Context, spaceIdentity string, inboundRulesetIdentity string) (*InboundRuleset, error) {
+	var inboundRuleset InboundRuleset
+	return &inboundRuleset, s.Get(ctx, &inboundRuleset, fmt.Sprintf("/spaces/%v/inbound-rulesets/%v", spaceIdentity, inboundRulesetIdentity), nil, nil)
 }
 
 type InboundRulesetListResult []InboundRuleset
@@ -2017,8 +2119,8 @@ func (s *Service) OAuthTokenDelete(ctx context.Context, oauthTokenIdentity strin
 	return &oauthToken, s.Delete(ctx, &oauthToken, fmt.Sprintf("/oauth/tokens/%v", oauthTokenIdentity))
 }
 
-// Organizations allow you to manage access to a shared group of
-// applications across your development team.
+// Deprecated: Organizations allow you to manage access to a shared
+// group of applications across your development team.
 type Organization struct {
 	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
 	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
@@ -2085,7 +2187,7 @@ func (s *Service) OrganizationDelete(ctx context.Context, organizationIdentity s
 	return &organization, s.Delete(ctx, &organization, fmt.Sprintf("/organizations/%v", organizationIdentity))
 }
 
-// A list of add-ons the Organization uses across all apps
+// Deprecated: A list of add-ons the Organization uses across all apps
 type OrganizationAddOn struct{}
 type OrganizationAddOnListForOrganizationResult []struct {
 	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
@@ -2117,8 +2219,8 @@ func (s *Service) OrganizationAddOnListForOrganization(ctx context.Context, orga
 	return organizationAddOn, s.Get(ctx, &organizationAddOn, fmt.Sprintf("/organizations/%v/addons", organizationIdentity), nil, lr)
 }
 
-// An organization app encapsulates the organization specific
-// functionality of Heroku apps.
+// Deprecated: An organization app encapsulates the organization
+// specific functionality of Heroku apps.
 type OrganizationApp struct {
 	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
 	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
@@ -2226,8 +2328,8 @@ func (s *Service) OrganizationAppTransferToOrganization(ctx context.Context, org
 	return &organizationApp, s.Patch(ctx, &organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
 }
 
-// An organization collaborator represents an account that has been
-// given access to an organization app on Heroku.
+// Deprecated: An organization collaborator represents an account that
+// has been given access to an organization app on Heroku.
 type OrganizationAppCollaborator struct {
 	App struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
@@ -2289,8 +2391,8 @@ func (s *Service) OrganizationAppCollaboratorList(ctx context.Context, organizat
 	return organizationAppCollaborator, s.Get(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators", organizationAppIdentity), nil, lr)
 }
 
-// An organization app permission is a behavior that is assigned to a
-// user in an organization app.
+// Deprecated: An organization app permission is a behavior that is
+// assigned to a user in an organization app.
 type OrganizationAppPermission struct {
 	Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
 	Name        string `json:"name" url:"name,key"`               // The name of the app permission.
@@ -2303,20 +2405,22 @@ func (s *Service) OrganizationAppPermissionList(ctx context.Context, lr *ListRan
 	return organizationAppPermission, s.Get(ctx, &organizationAppPermission, fmt.Sprintf("/organizations/permissions"), nil, lr)
 }
 
-// An organization feature represents a feature enabled on an
-// organization account.
+// Deprecated: An organization feature represents a feature enabled on
+// an organization account.
 type OrganizationFeature struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
+	CreatedAt     time.Time `json:"created_at" url:"created_at,key"`         // when organization feature was created
+	Description   string    `json:"description" url:"description,key"`       // description of organization feature
+	DisplayName   string    `json:"display_name" url:"display_name,key"`     // user readable feature name
+	DocURL        string    `json:"doc_url" url:"doc_url,key"`               // documentation URL of organization feature
+	Enabled       bool      `json:"enabled" url:"enabled,key"`               // whether or not organization feature has been enabled
+	FeedbackEmail string    `json:"feedback_email" url:"feedback_email,key"` // e-mail to send feedback about the feature
+	ID            string    `json:"id" url:"id,key"`                         // unique identifier of organization feature
+	Name          string    `json:"name" url:"name,key"`                     // unique name of organization feature
+	State         string    `json:"state" url:"state,key"`                   // state of organization feature
+	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`         // when organization feature was updated
 }
 
-// Info for an existing account feature.
+// Info for an existing organization feature.
 func (s *Service) OrganizationFeatureInfo(ctx context.Context, organizationIdentity string, organizationFeatureIdentity string) (*OrganizationFeature, error) {
 	var organizationFeature OrganizationFeature
 	return &organizationFeature, s.Get(ctx, &organizationFeature, fmt.Sprintf("/organizations/%v/features/%v", organizationIdentity, organizationFeatureIdentity), nil, nil)
@@ -2330,7 +2434,18 @@ func (s *Service) OrganizationFeatureList(ctx context.Context, organizationIdent
 	return organizationFeature, s.Get(ctx, &organizationFeature, fmt.Sprintf("/organizations/%v/features", organizationIdentity), nil, lr)
 }
 
-// An organization invitation represents an invite to an organization.
+type OrganizationFeatureUpdateOpts struct {
+	Enabled bool `json:"enabled" url:"enabled,key"` // whether or not organization feature has been enabled
+}
+
+// Update an existing organization feature.
+func (s *Service) OrganizationFeatureUpdate(ctx context.Context, organizationIdentity string, organizationFeatureIdentity string, o OrganizationFeatureUpdateOpts) (*OrganizationFeature, error) {
+	var organizationFeature OrganizationFeature
+	return &organizationFeature, s.Patch(ctx, &organizationFeature, fmt.Sprintf("/organizations/%v/features/%v", organizationIdentity, organizationFeatureIdentity), o)
+}
+
+// Deprecated: An organization invitation represents an invite to an
+// organization.
 type OrganizationInvitation struct {
 	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
 	ID        string    `json:"id" url:"id,key"`                 // Unique identifier of an invitation
@@ -2404,8 +2519,8 @@ func (s *Service) OrganizationInvitationAccept(ctx context.Context, organization
 	return &organizationInvitation, s.Post(ctx, &organizationInvitation, fmt.Sprintf("/organizations/invitations/%v/accept", organizationInvitationToken), nil)
 }
 
-// An organization invoice is an itemized bill of goods for an
-// organization which includes pricing and charges.
+// Deprecated: An organization invoice is an itemized bill of goods for
+// an organization which includes pricing and charges.
 type OrganizationInvoice struct {
 	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
 	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
@@ -2439,7 +2554,7 @@ func (s *Service) OrganizationInvoiceList(ctx context.Context, organizationIdent
 	return organizationInvoice, s.Get(ctx, &organizationInvoice, fmt.Sprintf("/organizations/%v/invoices", organizationIdentity), nil, lr)
 }
 
-// An organization member is an individual with access to an
+// Deprecated: An organization member is an individual with access to an
 // organization.
 type OrganizationMember struct {
 	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
@@ -2506,7 +2621,49 @@ func (s *Service) OrganizationMemberList(ctx context.Context, organizationIdenti
 	return organizationMember, s.Get(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), nil, lr)
 }
 
-// Tracks an organization's preferences
+type OrganizationMemberAppListResult []struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this app
+	Owner *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
+}
+
+// List the apps of a member.
+func (s *Service) OrganizationMemberAppList(ctx context.Context, organizationIdentity string, organizationMemberIdentity string, lr *ListRange) (OrganizationMemberAppListResult, error) {
+	var organizationMember OrganizationMemberAppListResult
+	return organizationMember, s.Get(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members/%v/apps", organizationIdentity, organizationMemberIdentity), nil, lr)
+}
+
+// Deprecated: Tracks an organization's preferences
 type OrganizationPreferences struct {
 	DefaultPermission *string `json:"default-permission" url:"default-permission,key"` // The default permission used when adding new members to the
 	// organization
@@ -2546,9 +2703,15 @@ type OutboundRuleset struct {
 }
 
 // Current outbound ruleset for a space
-func (s *Service) OutboundRulesetInfo(ctx context.Context, spaceIdentity string) (*OutboundRuleset, error) {
+func (s *Service) OutboundRulesetCurrent(ctx context.Context, spaceIdentity string) (*OutboundRuleset, error) {
 	var outboundRuleset OutboundRuleset
 	return &outboundRuleset, s.Get(ctx, &outboundRuleset, fmt.Sprintf("/spaces/%v/outbound-ruleset", spaceIdentity), nil, nil)
+}
+
+// Info on an existing Outbound Ruleset
+func (s *Service) OutboundRulesetInfo(ctx context.Context, spaceIdentity string, outboundRulesetIdentity string) (*OutboundRuleset, error) {
+	var outboundRuleset OutboundRuleset
+	return &outboundRuleset, s.Get(ctx, &outboundRuleset, fmt.Sprintf("/spaces/%v/outbound-rulesets/%v", spaceIdentity, outboundRulesetIdentity), nil, nil)
 }
 
 type OutboundRulesetListResult []OutboundRuleset
@@ -2666,12 +2829,20 @@ type PipelineCoupling struct {
 	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
 }
-type PipelineCouplingListResult []PipelineCoupling
+type PipelineCouplingListByPipelineResult []PipelineCoupling
 
 // List couplings for a pipeline
-func (s *Service) PipelineCouplingList(ctx context.Context, pipelineID string, lr *ListRange) (PipelineCouplingListResult, error) {
-	var pipelineCoupling PipelineCouplingListResult
+func (s *Service) PipelineCouplingListByPipeline(ctx context.Context, pipelineID string, lr *ListRange) (PipelineCouplingListByPipelineResult, error) {
+	var pipelineCoupling PipelineCouplingListByPipelineResult
 	return pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/pipelines/%v/pipeline-couplings", pipelineID), nil, lr)
+}
+
+type PipelineCouplingListResult []PipelineCoupling
+
+// List pipeline couplings.
+func (s *Service) PipelineCouplingList(ctx context.Context, lr *ListRange) (PipelineCouplingListResult, error) {
+	var pipelineCoupling PipelineCouplingListResult
+	return pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings"), nil, lr)
 }
 
 type PipelineCouplingCreateOpts struct {
@@ -2706,6 +2877,12 @@ type PipelineCouplingUpdateOpts struct {
 func (s *Service) PipelineCouplingUpdate(ctx context.Context, pipelineCouplingIdentity string, o PipelineCouplingUpdateOpts) (*PipelineCoupling, error) {
 	var pipelineCoupling PipelineCoupling
 	return &pipelineCoupling, s.Patch(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings/%v", pipelineCouplingIdentity), o)
+}
+
+// Info for an existing app pipeline coupling.
+func (s *Service) PipelineCouplingInfoByApp(ctx context.Context, appIdentity string) (*PipelineCoupling, error) {
+	var pipelineCoupling PipelineCoupling
+	return &pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/apps/%v/pipeline-couplings", appIdentity), nil, nil)
 }
 
 // Promotions allow you to move code from an app in a pipeline to all
@@ -2806,16 +2983,22 @@ type Plan struct {
 }
 
 // Info for existing plan.
-func (s *Service) PlanInfo(ctx context.Context, addOnServiceIdentity string, planIdentity string) (*Plan, error) {
+func (s *Service) PlanInfo(ctx context.Context, planIdentity string) (*Plan, error) {
+	var plan Plan
+	return &plan, s.Get(ctx, &plan, fmt.Sprintf("/plans/%v", planIdentity), nil, nil)
+}
+
+// Info for existing plan by Add-on.
+func (s *Service) PlanInfoByAddOn(ctx context.Context, addOnServiceIdentity string, planIdentity string) (*Plan, error) {
 	var plan Plan
 	return &plan, s.Get(ctx, &plan, fmt.Sprintf("/addon-services/%v/plans/%v", addOnServiceIdentity, planIdentity), nil, nil)
 }
 
-type PlanListResult []Plan
+type PlanListByAddOnResult []Plan
 
-// List existing plans.
-func (s *Service) PlanList(ctx context.Context, addOnServiceIdentity string, lr *ListRange) (PlanListResult, error) {
-	var plan PlanListResult
+// List existing plans by Add-on.
+func (s *Service) PlanListByAddOn(ctx context.Context, addOnServiceIdentity string, lr *ListRange) (PlanListByAddOnResult, error) {
+	var plan PlanListByAddOnResult
 	return plan, s.Get(ctx, &plan, fmt.Sprintf("/addon-services/%v/plans", addOnServiceIdentity), nil, lr)
 }
 
@@ -3082,8 +3265,12 @@ type Space struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of region
 		Name string `json:"name" url:"name,key"` // unique name of region
 	} `json:"region" url:"region,key"` // identity of space region
-	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
-	State     string    `json:"state" url:"state,key"`           // availability of this space
+	Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	State  string `json:"state" url:"state,key"`   // availability of this space
+	Team   struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of team
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // team that owns this space
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
 }
 type SpaceListResult []Space
@@ -3279,6 +3466,526 @@ func (s *Service) StackList(ctx context.Context, lr *ListRange) (StackListResult
 	return stack, s.Get(ctx, &stack, fmt.Sprintf("/stacks"), nil, lr)
 }
 
+// Teams allow you to manage access to a shared group of applications
+// and other resources.
+type Team struct {
+	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the team was created
+	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the team are paid by credit card.
+	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this team when none is specified
+	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of team
+	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in a team.
+	Name                  string    `json:"name" url:"name,key"`                                       // unique name of team
+	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the team is provisioned licenses by salesforce.
+	Role                  *string   `json:"role" url:"role,key"`                                       // role in the team
+	Type                  string    `json:"type" url:"type,key"`                                       // type of team.
+	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the team was updated
+}
+type TeamListResult []Team
+
+// List teams in which you are a member.
+func (s *Service) TeamList(ctx context.Context, lr *ListRange) (TeamListResult, error) {
+	var team TeamListResult
+	return team, s.Get(ctx, &team, fmt.Sprintf("/teams"), nil, lr)
+}
+
+// Info for a team.
+func (s *Service) TeamInfo(ctx context.Context, teamIdentity string) (*Team, error) {
+	var team Team
+	return &team, s.Get(ctx, &team, fmt.Sprintf("/teams/%v", teamIdentity), nil, nil)
+}
+
+type TeamUpdateOpts struct {
+	Default *bool   `json:"default,omitempty" url:"default,omitempty,key"` // whether to use this team when none is specified
+	Name    *string `json:"name,omitempty" url:"name,omitempty,key"`       // unique name of team
+}
+
+// Update team properties.
+func (s *Service) TeamUpdate(ctx context.Context, teamIdentity string, o TeamUpdateOpts) (*Team, error) {
+	var team Team
+	return &team, s.Patch(ctx, &team, fmt.Sprintf("/teams/%v", teamIdentity), o)
+}
+
+type TeamCreateOpts struct {
+	Address1        *string `json:"address_1,omitempty" url:"address_1,omitempty,key"`               // street address line 1
+	Address2        *string `json:"address_2,omitempty" url:"address_2,omitempty,key"`               // street address line 2
+	CardNumber      *string `json:"card_number,omitempty" url:"card_number,omitempty,key"`           // encrypted card number of payment method
+	City            *string `json:"city,omitempty" url:"city,omitempty,key"`                         // city
+	Country         *string `json:"country,omitempty" url:"country,omitempty,key"`                   // country
+	Cvv             *string `json:"cvv,omitempty" url:"cvv,omitempty,key"`                           // card verification value
+	ExpirationMonth *string `json:"expiration_month,omitempty" url:"expiration_month,omitempty,key"` // expiration month
+	ExpirationYear  *string `json:"expiration_year,omitempty" url:"expiration_year,omitempty,key"`   // expiration year
+	FirstName       *string `json:"first_name,omitempty" url:"first_name,omitempty,key"`             // the first name for payment method
+	LastName        *string `json:"last_name,omitempty" url:"last_name,omitempty,key"`               // the last name for payment method
+	Name            string  `json:"name" url:"name,key"`                                             // unique name of team
+	Other           *string `json:"other,omitempty" url:"other,omitempty,key"`                       // metadata
+	PostalCode      *string `json:"postal_code,omitempty" url:"postal_code,omitempty,key"`           // postal code
+	State           *string `json:"state,omitempty" url:"state,omitempty,key"`                       // state
+}
+
+// Create a new team.
+func (s *Service) TeamCreate(ctx context.Context, o TeamCreateOpts) (*Team, error) {
+	var team Team
+	return &team, s.Post(ctx, &team, fmt.Sprintf("/teams"), o)
+}
+
+// Delete an existing team.
+func (s *Service) TeamDelete(ctx context.Context, teamIdentity string) (*Team, error) {
+	var team Team
+	return &team, s.Delete(ctx, &team, fmt.Sprintf("/teams/%v", teamIdentity))
+}
+
+// An team app encapsulates the team specific functionality of Heroku
+// apps.
+type TeamApp struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Owner                        *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	Team *struct {
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // team that owns this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
+}
+type TeamAppCreateOpts struct {
+	Locked   *bool   `json:"locked,omitempty" url:"locked,omitempty,key"`     // are other team members forbidden from joining this app.
+	Name     *string `json:"name,omitempty" url:"name,omitempty,key"`         // unique name of app
+	Personal *bool   `json:"personal,omitempty" url:"personal,omitempty,key"` // force creation of the app in the user account even if a default team
+	// is set.
+	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique name of region
+	Space  *string `json:"space,omitempty" url:"space,omitempty,key"`   // unique name of space
+	Stack  *string `json:"stack,omitempty" url:"stack,omitempty,key"`   // unique name of stack
+	Team   *string `json:"team,omitempty" url:"team,omitempty,key"`     // unique name of team
+}
+
+// Create a new app in the specified team, in the default team if
+// unspecified, or in personal account, if default team is not set.
+func (s *Service) TeamAppCreate(ctx context.Context, o TeamAppCreateOpts) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Post(ctx, &teamApp, fmt.Sprintf("/teams/apps"), o)
+}
+
+type TeamAppListResult []TeamApp
+
+// List apps in the default team, or in personal account, if default
+// team is not set.
+func (s *Service) TeamAppList(ctx context.Context, lr *ListRange) (TeamAppListResult, error) {
+	var teamApp TeamAppListResult
+	return teamApp, s.Get(ctx, &teamApp, fmt.Sprintf("/teams/apps"), nil, lr)
+}
+
+// Info for a team app.
+func (s *Service) TeamAppInfo(ctx context.Context, teamAppIdentity string) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Get(ctx, &teamApp, fmt.Sprintf("/teams/apps/%v", teamAppIdentity), nil, nil)
+}
+
+type TeamAppUpdateLockedOpts struct {
+	Locked bool `json:"locked" url:"locked,key"` // are other team members forbidden from joining this app.
+}
+
+// Lock or unlock a team app.
+func (s *Service) TeamAppUpdateLocked(ctx context.Context, teamAppIdentity string, o TeamAppUpdateLockedOpts) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Patch(ctx, &teamApp, fmt.Sprintf("/teams/apps/%v", teamAppIdentity), o)
+}
+
+type TeamAppTransferToAccountOpts struct {
+	Owner string `json:"owner" url:"owner,key"` // unique email address of account
+}
+
+// Transfer an existing team app to another Heroku account.
+func (s *Service) TeamAppTransferToAccount(ctx context.Context, teamAppIdentity string, o TeamAppTransferToAccountOpts) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Patch(ctx, &teamApp, fmt.Sprintf("/teams/apps/%v", teamAppIdentity), o)
+}
+
+type TeamAppTransferToTeamOpts struct {
+	Owner string `json:"owner" url:"owner,key"` // unique name of team
+}
+
+// Transfer an existing team app to another team.
+func (s *Service) TeamAppTransferToTeam(ctx context.Context, teamAppIdentity string, o TeamAppTransferToTeamOpts) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Patch(ctx, &teamApp, fmt.Sprintf("/teams/apps/%v", teamAppIdentity), o)
+}
+
+type TeamAppListByTeamResult []TeamApp
+
+// List team apps.
+func (s *Service) TeamAppListByTeam(ctx context.Context, teamIdentity string, lr *ListRange) (TeamAppListByTeamResult, error) {
+	var teamApp TeamAppListByTeamResult
+	return teamApp, s.Get(ctx, &teamApp, fmt.Sprintf("/teams/%v/apps", teamIdentity), nil, lr)
+}
+
+// A team collaborator represents an account that has been given access
+// to a team app on Heroku.
+type TeamAppCollaborator struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Role      *string   `json:"role" url:"role,key"`             // role in the team
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
+}
+type TeamAppCollaboratorCreateOpts struct {
+	Permissions *[]*string `json:"permissions,omitempty" url:"permissions,omitempty,key"` // An array of permissions to give to the collaborator.
+	Silent      *bool      `json:"silent,omitempty" url:"silent,omitempty,key"`           // whether to suppress email invitation when creating collaborator
+	User        string     `json:"user" url:"user,key"`                                   // unique email address of account
+}
+
+// Create a new collaborator on a team app. Use this endpoint instead of
+// the `/apps/{app_id_or_name}/collaborator` endpoint when you want the
+// collaborator to be granted [permissions]
+// (https://devcenter.heroku.com/articles/org-users-access#roles-and-app-
+// permissions) according to their role in the team.
+func (s *Service) TeamAppCollaboratorCreate(ctx context.Context, appIdentity string, o TeamAppCollaboratorCreateOpts) (*TeamAppCollaborator, error) {
+	var teamAppCollaborator TeamAppCollaborator
+	return &teamAppCollaborator, s.Post(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators", appIdentity), o)
+}
+
+// Delete an existing collaborator from a team app.
+func (s *Service) TeamAppCollaboratorDelete(ctx context.Context, teamAppIdentity string, teamAppCollaboratorIdentity string) (*TeamAppCollaborator, error) {
+	var teamAppCollaborator TeamAppCollaborator
+	return &teamAppCollaborator, s.Delete(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators/%v", teamAppIdentity, teamAppCollaboratorIdentity))
+}
+
+// Info for a collaborator on a team app.
+func (s *Service) TeamAppCollaboratorInfo(ctx context.Context, teamAppIdentity string, teamAppCollaboratorIdentity string) (*TeamAppCollaborator, error) {
+	var teamAppCollaborator TeamAppCollaborator
+	return &teamAppCollaborator, s.Get(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators/%v", teamAppIdentity, teamAppCollaboratorIdentity), nil, nil)
+}
+
+type TeamAppCollaboratorUpdateOpts struct {
+	Permissions []string `json:"permissions" url:"permissions,key"` // An array of permissions to give to the collaborator.
+}
+
+// Update an existing collaborator from a team app.
+func (s *Service) TeamAppCollaboratorUpdate(ctx context.Context, teamAppIdentity string, teamAppCollaboratorIdentity string, o TeamAppCollaboratorUpdateOpts) (*TeamAppCollaborator, error) {
+	var teamAppCollaborator TeamAppCollaborator
+	return &teamAppCollaborator, s.Patch(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators/%v", teamAppIdentity, teamAppCollaboratorIdentity), o)
+}
+
+type TeamAppCollaboratorListResult []TeamAppCollaborator
+
+// List collaborators on a team app.
+func (s *Service) TeamAppCollaboratorList(ctx context.Context, teamAppIdentity string, lr *ListRange) (TeamAppCollaboratorListResult, error) {
+	var teamAppCollaborator TeamAppCollaboratorListResult
+	return teamAppCollaborator, s.Get(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators", teamAppIdentity), nil, lr)
+}
+
+// A team app permission is a behavior that is assigned to a user in a
+// team app.
+type TeamAppPermission struct {
+	Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+	Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+}
+type TeamAppPermissionListResult []TeamAppPermission
+
+// Lists permissions available to teams.
+func (s *Service) TeamAppPermissionList(ctx context.Context, lr *ListRange) (TeamAppPermissionListResult, error) {
+	var teamAppPermission TeamAppPermissionListResult
+	return teamAppPermission, s.Get(ctx, &teamAppPermission, fmt.Sprintf("/teams/permissions"), nil, lr)
+}
+
+// A team feature represents a feature enabled on a team account.
+type TeamFeature struct {
+	CreatedAt     time.Time `json:"created_at" url:"created_at,key"`         // when team feature was created
+	Description   string    `json:"description" url:"description,key"`       // description of team feature
+	DisplayName   string    `json:"display_name" url:"display_name,key"`     // user readable feature name
+	DocURL        string    `json:"doc_url" url:"doc_url,key"`               // documentation URL of team feature
+	Enabled       bool      `json:"enabled" url:"enabled,key"`               // whether or not team feature has been enabled
+	FeedbackEmail string    `json:"feedback_email" url:"feedback_email,key"` // e-mail to send feedback about the feature
+	ID            string    `json:"id" url:"id,key"`                         // unique identifier of team feature
+	Name          string    `json:"name" url:"name,key"`                     // unique name of team feature
+	State         string    `json:"state" url:"state,key"`                   // state of team feature
+	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`         // when team feature was updated
+}
+
+// Info for an existing team feature.
+func (s *Service) TeamFeatureInfo(ctx context.Context, teamIdentity string, teamFeatureIdentity string) (*TeamFeature, error) {
+	var teamFeature TeamFeature
+	return &teamFeature, s.Get(ctx, &teamFeature, fmt.Sprintf("/teams/%v/features/%v", teamIdentity, teamFeatureIdentity), nil, nil)
+}
+
+type TeamFeatureListResult []TeamFeature
+
+// List existing team features.
+func (s *Service) TeamFeatureList(ctx context.Context, teamIdentity string, lr *ListRange) (TeamFeatureListResult, error) {
+	var teamFeature TeamFeatureListResult
+	return teamFeature, s.Get(ctx, &teamFeature, fmt.Sprintf("/teams/%v/features", teamIdentity), nil, lr)
+}
+
+// A team invitation represents an invite to a team.
+type TeamInvitation struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an invitation
+	InvitedBy struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"invited_by" url:"invited_by,key"`
+	Role *string `json:"role" url:"role,key"` // role in the team
+	Team struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of team
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"`
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when invitation was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"`
+}
+type TeamInvitationListResult []TeamInvitation
+
+// Get a list of a team's Identity Providers
+func (s *Service) TeamInvitationList(ctx context.Context, teamName string, lr *ListRange) (TeamInvitationListResult, error) {
+	var teamInvitation TeamInvitationListResult
+	return teamInvitation, s.Get(ctx, &teamInvitation, fmt.Sprintf("/teams/%v/invitations", teamName), nil, lr)
+}
+
+type TeamInvitationCreateOpts struct {
+	Email string  `json:"email" url:"email,key"` // unique email address of account
+	Role  *string `json:"role" url:"role,key"`   // role in the team
+}
+
+// Create Team Invitation
+func (s *Service) TeamInvitationCreate(ctx context.Context, teamIdentity string, o TeamInvitationCreateOpts) (*TeamInvitation, error) {
+	var teamInvitation TeamInvitation
+	return &teamInvitation, s.Put(ctx, &teamInvitation, fmt.Sprintf("/teams/%v/invitations", teamIdentity), o)
+}
+
+// Revoke a team invitation.
+func (s *Service) TeamInvitationRevoke(ctx context.Context, teamIdentity string, teamInvitationIdentity string) (*TeamInvitation, error) {
+	var teamInvitation TeamInvitation
+	return &teamInvitation, s.Delete(ctx, &teamInvitation, fmt.Sprintf("/teams/%v/invitations/%v", teamIdentity, teamInvitationIdentity))
+}
+
+// Get an invitation by its token
+func (s *Service) TeamInvitationGet(ctx context.Context, teamInvitationToken string, lr *ListRange) (*TeamInvitation, error) {
+	var teamInvitation TeamInvitation
+	return &teamInvitation, s.Get(ctx, &teamInvitation, fmt.Sprintf("/teams/invitations/%v", teamInvitationToken), nil, lr)
+}
+
+type TeamInvitationAcceptResult struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the team member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of the team member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the team
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise team member has two factor authentication
+	// enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
+}
+
+// Accept Team Invitation
+func (s *Service) TeamInvitationAccept(ctx context.Context, teamInvitationToken string) (*TeamInvitationAcceptResult, error) {
+	var teamInvitation TeamInvitationAcceptResult
+	return &teamInvitation, s.Post(ctx, &teamInvitation, fmt.Sprintf("/teams/invitations/%v/accept", teamInvitationToken), nil)
+}
+
+// A Team Invoice is an itemized bill of goods for a team which includes
+// pricing and charges.
+type TeamInvoice struct {
+	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
+	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                   // when invoice was created
+	CreditsTotal      int       `json:"credits_total" url:"credits_total,key"`             // total credits on this invoice
+	DatabaseTotal     int       `json:"database_total" url:"database_total,key"`           // total database charges on this invoice
+	DynoUnits         float64   `json:"dyno_units" url:"dyno_units,key"`                   // total amount of dyno units consumed across dyno types.
+	ID                string    `json:"id" url:"id,key"`                                   // unique identifier of this invoice
+	Number            int       `json:"number" url:"number,key"`                           // human readable invoice number
+	PaymentStatus     string    `json:"payment_status" url:"payment_status,key"`           // status of the invoice payment
+	PeriodEnd         string    `json:"period_end" url:"period_end,key"`                   // the ending date that the invoice covers
+	PeriodStart       string    `json:"period_start" url:"period_start,key"`               // the starting date that this invoice covers
+	PlatformTotal     int       `json:"platform_total" url:"platform_total,key"`           // total platform charges on this invoice
+	State             int       `json:"state" url:"state,key"`                             // payment status for this invoice (pending, successful, failed)
+	Total             int       `json:"total" url:"total,key"`                             // combined total of charges and credits on this invoice
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                   // when invoice was updated
+	WeightedDynoHours float64   `json:"weighted_dyno_hours" url:"weighted_dyno_hours,key"` // The total amount of hours consumed across dyno types.
+}
+
+// Info for existing invoice.
+func (s *Service) TeamInvoiceInfo(ctx context.Context, teamIdentity string, teamInvoiceIdentity int) (*TeamInvoice, error) {
+	var teamInvoice TeamInvoice
+	return &teamInvoice, s.Get(ctx, &teamInvoice, fmt.Sprintf("/teams/%v/invoices/%v", teamIdentity, teamInvoiceIdentity), nil, nil)
+}
+
+type TeamInvoiceListResult []TeamInvoice
+
+// List existing invoices.
+func (s *Service) TeamInvoiceList(ctx context.Context, teamIdentity string, lr *ListRange) (TeamInvoiceListResult, error) {
+	var teamInvoice TeamInvoiceListResult
+	return teamInvoice, s.Get(ctx, &teamInvoice, fmt.Sprintf("/teams/%v/invoices", teamIdentity), nil, lr)
+}
+
+// A team member is an individual with access to a team.
+type TeamMember struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the team member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of the team member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the team
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise team member has two factor authentication
+	// enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
+}
+type TeamMemberCreateOrUpdateOpts struct {
+	Email     string  `json:"email" url:"email,key"`                             // email address of the team member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the team
+}
+
+// Create a new team member, or update their role.
+func (s *Service) TeamMemberCreateOrUpdate(ctx context.Context, teamIdentity string, o TeamMemberCreateOrUpdateOpts) (*TeamMember, error) {
+	var teamMember TeamMember
+	return &teamMember, s.Put(ctx, &teamMember, fmt.Sprintf("/teams/%v/members", teamIdentity), o)
+}
+
+type TeamMemberCreateOpts struct {
+	Email     string  `json:"email" url:"email,key"`                             // email address of the team member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the team
+}
+
+// Create a new team member.
+func (s *Service) TeamMemberCreate(ctx context.Context, teamIdentity string, o TeamMemberCreateOpts) (*TeamMember, error) {
+	var teamMember TeamMember
+	return &teamMember, s.Post(ctx, &teamMember, fmt.Sprintf("/teams/%v/members", teamIdentity), o)
+}
+
+type TeamMemberUpdateOpts struct {
+	Email     string  `json:"email" url:"email,key"`                             // email address of the team member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the team
+}
+
+// Update a team member.
+func (s *Service) TeamMemberUpdate(ctx context.Context, teamIdentity string, o TeamMemberUpdateOpts) (*TeamMember, error) {
+	var teamMember TeamMember
+	return &teamMember, s.Patch(ctx, &teamMember, fmt.Sprintf("/teams/%v/members", teamIdentity), o)
+}
+
+// Remove a member from the team.
+func (s *Service) TeamMemberDelete(ctx context.Context, teamIdentity string, teamMemberIdentity string) (*TeamMember, error) {
+	var teamMember TeamMember
+	return &teamMember, s.Delete(ctx, &teamMember, fmt.Sprintf("/teams/%v/members/%v", teamIdentity, teamMemberIdentity))
+}
+
+type TeamMemberListResult []TeamMember
+
+// List members of the team.
+func (s *Service) TeamMemberList(ctx context.Context, teamIdentity string, lr *ListRange) (TeamMemberListResult, error) {
+	var teamMember TeamMemberListResult
+	return teamMember, s.Get(ctx, &teamMember, fmt.Sprintf("/teams/%v/members", teamIdentity), nil, lr)
+}
+
+type TeamMemberListByMemberResult []struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Owner                        *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	Team *struct {
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // team that owns this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
+}
+
+// List the apps of a team member.
+func (s *Service) TeamMemberListByMember(ctx context.Context, teamIdentity string, teamMemberIdentity string, lr *ListRange) (TeamMemberListByMemberResult, error) {
+	var teamMember TeamMemberListByMemberResult
+	return teamMember, s.Get(ctx, &teamMember, fmt.Sprintf("/teams/%v/members/%v/apps", teamIdentity, teamMemberIdentity), nil, lr)
+}
+
+// Tracks a Team's Preferences
+type TeamPreferences struct {
+	DefaultPermission   *string `json:"default-permission" url:"default-permission,key"`     // The default permission used when adding new members to the team
+	WhitelistingEnabled *bool   `json:"whitelisting-enabled" url:"whitelisting-enabled,key"` // Whether whitelisting rules should be applied to add-on installations
+}
+
+// Retrieve Team Preferences
+func (s *Service) TeamPreferencesList(ctx context.Context, teamPreferencesIdentity string) (*TeamPreferences, error) {
+	var teamPreferences TeamPreferences
+	return &teamPreferences, s.Get(ctx, &teamPreferences, fmt.Sprintf("/teams/%v/preferences", teamPreferencesIdentity), nil, nil)
+}
+
+type TeamPreferencesUpdateOpts struct {
+	WhitelistingEnabled *bool `json:"whitelisting-enabled,omitempty" url:"whitelisting-enabled,omitempty,key"` // Whether whitelisting rules should be applied to add-on installations
+}
+
+// Update Team Preferences
+func (s *Service) TeamPreferencesUpdate(ctx context.Context, teamPreferencesIdentity string, o TeamPreferencesUpdateOpts) (*TeamPreferences, error) {
+	var teamPreferences TeamPreferences
+	return &teamPreferences, s.Patch(ctx, &teamPreferences, fmt.Sprintf("/teams/%v/preferences", teamPreferencesIdentity), o)
+}
+
 // Tracks a user's preferences and message dismissals
 type UserPreferences struct {
 	DefaultOrganization        *string `json:"default-organization" url:"default-organization,key"`                   // User's default organization
@@ -3336,28 +4043,53 @@ type WhitelistedAddOnService struct {
 	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
 	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
 }
-type WhitelistedAddOnServiceListResult []WhitelistedAddOnService
+type WhitelistedAddOnServiceListByOrganizationResult []WhitelistedAddOnService
 
 // List all whitelisted Add-on Services for an Organization
-func (s *Service) WhitelistedAddOnServiceList(ctx context.Context, organizationIdentity string, lr *ListRange) (WhitelistedAddOnServiceListResult, error) {
-	var whitelistedAddOnService WhitelistedAddOnServiceListResult
+func (s *Service) WhitelistedAddOnServiceListByOrganization(ctx context.Context, organizationIdentity string, lr *ListRange) (WhitelistedAddOnServiceListByOrganizationResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceListByOrganizationResult
 	return whitelistedAddOnService, s.Get(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services", organizationIdentity), nil, lr)
 }
 
-type WhitelistedAddOnServiceCreateOpts struct {
+type WhitelistedAddOnServiceCreateByOrganizationOpts struct {
 	AddonService *string `json:"addon_service,omitempty" url:"addon_service,omitempty,key"` // name of the Add-on to whitelist
 }
-type WhitelistedAddOnServiceCreateResult []WhitelistedAddOnService
+type WhitelistedAddOnServiceCreateByOrganizationResult []WhitelistedAddOnService
 
 // Whitelist an Add-on Service
-func (s *Service) WhitelistedAddOnServiceCreate(ctx context.Context, organizationIdentity string, o WhitelistedAddOnServiceCreateOpts) (WhitelistedAddOnServiceCreateResult, error) {
-	var whitelistedAddOnService WhitelistedAddOnServiceCreateResult
+func (s *Service) WhitelistedAddOnServiceCreateByOrganization(ctx context.Context, organizationIdentity string, o WhitelistedAddOnServiceCreateByOrganizationOpts) (WhitelistedAddOnServiceCreateByOrganizationResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceCreateByOrganizationResult
 	return whitelistedAddOnService, s.Post(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services", organizationIdentity), o)
 }
 
 // Remove a whitelisted entity
-func (s *Service) WhitelistedAddOnServiceDelete(ctx context.Context, organizationIdentity string, whitelistedAddOnServiceIdentity string) (*WhitelistedAddOnService, error) {
+func (s *Service) WhitelistedAddOnServiceDeleteByOrganization(ctx context.Context, organizationIdentity string, whitelistedAddOnServiceIdentity string) (*WhitelistedAddOnService, error) {
 	var whitelistedAddOnService WhitelistedAddOnService
 	return &whitelistedAddOnService, s.Delete(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services/%v", organizationIdentity, whitelistedAddOnServiceIdentity))
+}
+
+type WhitelistedAddOnServiceListByTeamResult []WhitelistedAddOnService
+
+// List all whitelisted Add-on Services for a Team
+func (s *Service) WhitelistedAddOnServiceListByTeam(ctx context.Context, teamIdentity string, lr *ListRange) (WhitelistedAddOnServiceListByTeamResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceListByTeamResult
+	return whitelistedAddOnService, s.Get(ctx, &whitelistedAddOnService, fmt.Sprintf("/teams/%v/whitelisted-addon-services", teamIdentity), nil, lr)
+}
+
+type WhitelistedAddOnServiceCreateByTeamOpts struct {
+	AddonService *string `json:"addon_service,omitempty" url:"addon_service,omitempty,key"` // name of the Add-on to whitelist
+}
+type WhitelistedAddOnServiceCreateByTeamResult []WhitelistedAddOnService
+
+// Whitelist an Add-on Service
+func (s *Service) WhitelistedAddOnServiceCreateByTeam(ctx context.Context, teamIdentity string, o WhitelistedAddOnServiceCreateByTeamOpts) (WhitelistedAddOnServiceCreateByTeamResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceCreateByTeamResult
+	return whitelistedAddOnService, s.Post(ctx, &whitelistedAddOnService, fmt.Sprintf("/teams/%v/whitelisted-addon-services", teamIdentity), o)
+}
+
+// Remove a whitelisted entity
+func (s *Service) WhitelistedAddOnServiceDeleteByTeam(ctx context.Context, teamIdentity string, whitelistedAddOnServiceIdentity string) (*WhitelistedAddOnService, error) {
+	var whitelistedAddOnService WhitelistedAddOnService
+	return &whitelistedAddOnService, s.Delete(ctx, &whitelistedAddOnService, fmt.Sprintf("/teams/%v/whitelisted-addon-services/%v", teamIdentity, whitelistedAddOnServiceIdentity))
 }
 

--- a/v3/schema.json
+++ b/v3/schema.json
@@ -90,6 +90,22 @@
           "type": [
             "string"
           ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
@@ -166,6 +182,12 @@
         },
         "updated_at": {
           "$ref": "#/definitions/account-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/account-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/account-feature/definitions/feedback_email"
         }
       }
     },
@@ -394,7 +416,7 @@
           "targetSchema": {
             "$ref": "#/definitions/account"
           },
-          "title": "Info"
+          "title": "Info By User"
         },
         {
           "description": "Update account.",
@@ -420,7 +442,7 @@
           "targetSchema": {
             "$ref": "#/definitions/account"
           },
-          "title": "Update"
+          "title": "Update By User"
         },
         {
           "description": "Delete account. Note that this action cannot be undone.",
@@ -430,7 +452,7 @@
           "targetSchema": {
             "$ref": "#/definitions/account"
           },
-          "title": "Delete"
+          "title": "Delete By User"
         }
       ],
       "properties": {
@@ -536,7 +558,7 @@
           "targetSchema": {
             "$ref": "#/definitions/add-on"
           },
-          "title": "Create - Provision"
+          "title": "Provision"
         },
         {
           "description": "Mark an add-on as deprovisioned.",
@@ -546,7 +568,7 @@
           "targetSchema": {
             "$ref": "#/definitions/add-on"
           },
-          "title": "Create - Deprovision"
+          "title": "Deprovision"
         }
       ],
       "properties": {
@@ -614,6 +636,15 @@
             "string"
           ]
         },
+        "namespace": {
+          "description": "attachment namespace",
+          "example": "role:analytics",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "updated_at": {
           "description": "when add-on attachment was updated",
           "example": "2012-01-01T12:00:00Z",
@@ -653,6 +684,9 @@
               },
               "name": {
                 "$ref": "#/definitions/add-on-attachment/definitions/name"
+              },
+              "namespace": {
+                "$ref": "#/definitions/add-on-attachment/definitions/namespace"
               }
             },
             "required": [
@@ -818,6 +852,9 @@
         },
         "name": {
           "$ref": "#/definitions/add-on-attachment/definitions/name"
+        },
+        "namespace": {
+          "$ref": "#/definitions/add-on-attachment/definitions/namespace"
         },
         "updated_at": {
           "$ref": "#/definitions/add-on-attachment/definitions/updated_at"
@@ -1063,7 +1100,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Region"
         }
       ],
       "properties": {
@@ -1378,6 +1415,31 @@
       },
       "links": [
         {
+          "description": "List all existing add-ons.",
+          "href": "/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for an existing add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Info"
+        },
+        {
           "description": "Create a new add-on.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons",
           "method": "POST",
@@ -1447,47 +1509,7 @@
           "targetSchema": {
             "$ref": "#/definitions/add-on"
           },
-          "title": "Info"
-        },
-        {
-          "description": "List all existing add-ons.",
-          "href": "/addons",
-          "method": "GET",
-          "rel": "instances",
-          "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/add-on"
-            },
-            "type": [
-              "array"
-            ]
-          },
-          "title": "List"
-        },
-        {
-          "description": "Info for an existing add-on.",
-          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/add-on"
-          },
-          "title": "Info"
-        },
-        {
-          "description": "List all existing add-ons a user has access to",
-          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/addons",
-          "method": "GET",
-          "rel": "instances",
-          "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/add-on"
-            },
-            "type": [
-              "array"
-            ]
-          },
-          "title": "List by User"
+          "title": "Info By App"
         },
         {
           "description": "List existing add-ons for an app.",
@@ -1502,7 +1524,7 @@
               "array"
             ]
           },
-          "title": "List by App"
+          "title": "List By App"
         },
         {
           "description": "Change add-on plan. Some add-ons may not support changing plans. In that case, an error will be returned.",
@@ -1523,6 +1545,36 @@
             ]
           },
           "title": "Update"
+        },
+        {
+          "description": "List all existing add-ons a user has access to",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By User"
+        },
+        {
+          "description": "List add-ons used across all Team apps",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
         }
       ],
       "properties": {
@@ -1686,6 +1738,22 @@
           "type": [
             "string"
           ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
@@ -1762,6 +1830,12 @@
         },
         "updated_at": {
           "$ref": "#/definitions/app-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/app-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/app-feature/definitions/feedback_email"
         }
       }
     },
@@ -2597,7 +2671,7 @@
           "title": "List"
         },
         {
-          "description": "List owned and collaborated apps (excludes organization apps).",
+          "description": "List owned and collaborated apps (excludes team apps).",
           "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/apps",
           "method": "GET",
           "ranges": [
@@ -2703,6 +2777,21 @@
             },
             "name": {
               "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "team": {
+          "description": "identity of team",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
             }
           },
           "type": [
@@ -3443,11 +3532,11 @@
             "array"
           ],
           "items": {
-            "$ref": "#/definitions/organization-app-permission"
+            "$ref": "#/definitions/team-app-permission"
           }
         },
         "role": {
-          "$ref": "#/definitions/organization/definitions/role"
+          "$ref": "#/definitions/team/definitions/role"
         },
         "updated_at": {
           "$ref": "#/definitions/collaborator/definitions/updated_at"
@@ -4455,6 +4544,9 @@
             },
             {
               "$ref": "#/definitions/space"
+            },
+            {
+              "$ref": "#/definitions/team"
             }
           ],
           "readOnly": true,
@@ -4507,6 +4599,7 @@
             "organization",
             "release",
             "space",
+            "team",
             "user"
           ],
           "example": "app",
@@ -4782,7 +4875,7 @@
           },
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/organization-app"
+              "$ref": "#/definitions/team-app"
             },
             "type": [
               "array"
@@ -4952,7 +5045,7 @@
               "array"
             ]
           },
-          "title": "Batch update"
+          "title": "Batch Update"
         },
         {
           "description": "Update process type",
@@ -5103,7 +5196,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Organization"
         },
         {
           "description": "Create an Identity Provider for an organization",
@@ -5137,7 +5230,7 @@
           "targetSchema": {
             "$ref": "#/definitions/identity-provider"
           },
-          "title": "Create"
+          "title": "Create By Organization"
         },
         {
           "description": "Update an organization's Identity Provider",
@@ -5166,7 +5259,7 @@
           "targetSchema": {
             "$ref": "#/definitions/identity-provider"
           },
-          "title": "Update"
+          "title": "Update By Organization"
         },
         {
           "description": "Delete an organization's Identity Provider",
@@ -5176,7 +5269,95 @@
           "targetSchema": {
             "$ref": "#/definitions/identity-provider"
           },
-          "title": "Delete"
+          "title": "Delete By Organization"
+        },
+        {
+          "description": "Get a list of a team's Identity Providers",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/identity-providers",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/identity-provider"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        },
+        {
+          "description": "Create an Identity Provider for a team",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/identity-providers",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "required": [
+              "certificate",
+              "sso_target_url",
+              "entity_id"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Create By Team"
+        },
+        {
+          "description": "Update a team's Identity Provider",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Update By Team"
+        },
+        {
+          "description": "Delete a team's Identity Provider",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Delete By Team"
         }
       ],
       "properties": {
@@ -5299,7 +5480,7 @@
           "targetSchema": {
             "$ref": "#/definitions/inbound-ruleset"
           },
-          "title": "Info"
+          "title": "Current"
         },
         {
           "description": "Info on an existing Inbound Ruleset",
@@ -7080,8 +7261,9 @@
     },
     "organization-add-on": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "A list of add-ons the Organization uses across all apps",
+      "description": "Deprecated: A list of add-ons the Organization uses across all apps",
       "stability": "production",
+      "deprecated_at": "2017-04-10",
       "title": "Heroku Platform API - Organization Add-on",
       "type": [
         "object"
@@ -7105,9 +7287,10 @@
       ]
     },
     "organization-app-collaborator": {
-      "description": "An organization collaborator represents an account that has been given access to an organization app on Heroku.",
+      "description": "Deprecated: An organization collaborator represents an account that has been given access to an organization app on Heroku.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "title": "Heroku Platform API - Organization App Collaborator",
       "type": [
         "object"
@@ -7272,8 +7455,9 @@
     },
     "organization-app": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An organization app encapsulates the organization specific functionality of Heroku apps.",
+      "description": "Deprecated: An organization app encapsulates the organization specific functionality of Heroku apps.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "title": "Heroku Platform API - Organization App",
       "type": [
         "object"
@@ -7567,9 +7751,10 @@
       }
     },
     "organization-feature": {
-      "description": "An organization feature represents a feature enabled on an organization account.",
+      "description": "Deprecated: An organization feature represents a feature enabled on an organization account.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization Feature",
       "type": [
@@ -7602,7 +7787,7 @@
           ]
         },
         "enabled": {
-          "description": "whether or not account feature has been enabled",
+          "description": "whether or not organization feature has been enabled",
           "example": true,
           "readOnly": false,
           "type": [
@@ -7652,11 +7837,27 @@
           "type": [
             "string"
           ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
         {
-          "description": "Info for an existing account feature.",
+          "description": "Info for an existing organization feature.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Forganization-feature%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
@@ -7679,39 +7880,69 @@
             ]
           },
           "title": "List"
+        },
+        {
+          "description": "Update an existing organization feature.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Forganization-feature%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "enabled": {
+                "$ref": "#/definitions/organization-feature/definitions/enabled"
+              }
+            },
+            "required": [
+              "enabled"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-feature"
+          },
+          "title": "Update"
         }
       ],
       "properties": {
         "created_at": {
-          "$ref": "#/definitions/account-feature/definitions/created_at"
+          "$ref": "#/definitions/organization-feature/definitions/created_at"
         },
         "description": {
-          "$ref": "#/definitions/account-feature/definitions/description"
+          "$ref": "#/definitions/organization-feature/definitions/description"
         },
         "doc_url": {
-          "$ref": "#/definitions/account-feature/definitions/doc_url"
+          "$ref": "#/definitions/organization-feature/definitions/doc_url"
         },
         "enabled": {
-          "$ref": "#/definitions/account-feature/definitions/enabled"
+          "$ref": "#/definitions/organization-feature/definitions/enabled"
         },
         "id": {
-          "$ref": "#/definitions/account-feature/definitions/id"
+          "$ref": "#/definitions/organization-feature/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/account-feature/definitions/name"
+          "$ref": "#/definitions/organization-feature/definitions/name"
         },
         "state": {
-          "$ref": "#/definitions/account-feature/definitions/state"
+          "$ref": "#/definitions/organization-feature/definitions/state"
         },
         "updated_at": {
-          "$ref": "#/definitions/account-feature/definitions/updated_at"
+          "$ref": "#/definitions/organization-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/organization-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/organization-feature/definitions/feedback_email"
         }
       }
     },
     "organization-invitation": {
-      "description": "An organization invitation represents an invite to an organization.",
+      "description": "Deprecated: An organization invitation represents an invite to an organization.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization Invitation",
       "type": [
@@ -7894,8 +8125,9 @@
     },
     "organization-invoice": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.",
+      "description": "Deprecated: An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization Invoice",
       "type": [
@@ -8121,8 +8353,9 @@
     },
     "organization-member": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An organization member is an individual with access to an organization.",
+      "description": "Deprecated: An organization member is an individual with access to an organization.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "additionalProperties": false,
       "required": [
         "created_at",
@@ -8338,7 +8571,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "App List"
         }
       ],
       "properties": {
@@ -8384,9 +8617,10 @@
       }
     },
     "organization-preferences": {
-      "description": "Tracks an organization's preferences",
+      "description": "Deprecated: Tracks an organization's preferences",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization Preferences",
       "type": [
@@ -8464,8 +8698,9 @@
     },
     "organization": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "Organizations allow you to manage access to a shared group of applications across your development team.",
+      "description": "Deprecated: Organizations allow you to manage access to a shared group of applications across your development team.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization",
       "type": [
@@ -8918,7 +9153,7 @@
           "targetSchema": {
             "$ref": "#/definitions/outbound-ruleset"
           },
-          "title": "Info"
+          "title": "Current"
         },
         {
           "description": "Info on an existing Outbound Ruleset",
@@ -9093,8 +9328,9 @@
     },
     "organization-app-permission": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An organization app permission is a behavior that is assigned to a user in an organization app.",
+      "description": "Deprecated: An organization app permission is a behavior that is assigned to a user in an organization app.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "title": "Heroku Platform API - Organization App Permission",
       "type": [
         "object"
@@ -9222,7 +9458,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Pipeline"
         },
         {
           "description": "List pipeline couplings.",
@@ -9311,14 +9547,14 @@
           "title": "Update"
         },
         {
-          "description": "Info for an existing pipeline coupling.",
+          "description": "Info for an existing app pipeline coupling.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/pipeline-couplings",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
             "$ref": "#/definitions/pipeline-coupling"
           },
-          "title": "Info"
+          "title": "Info By App"
         }
       ],
       "properties": {
@@ -9992,16 +10228,6 @@
       "links": [
         {
           "description": "Info for existing plan.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/plan"
-          },
-          "title": "Info"
-        },
-        {
-          "description": "Info for existing plan.",
           "href": "/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
@@ -10011,7 +10237,17 @@
           "title": "Info"
         },
         {
-          "description": "List existing plans.",
+          "description": "Info for existing plan by Add-on.",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/plan"
+          },
+          "title": "Info By Add-on"
+        },
+        {
+          "description": "List existing plans by Add-on.",
           "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans",
           "method": "GET",
           "rel": "instances",
@@ -10023,7 +10259,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Add-on"
         }
       ],
       "properties": {
@@ -11540,6 +11776,20 @@
             "object"
           ]
         },
+        "team": {
+          "description": "team that owns this space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
         "region": {
           "description": "identity of space region",
           "properties": {
@@ -11906,6 +12156,1805 @@
         }
       }
     },
+    "team-app-collaborator": {
+      "description": "A team collaborator represents an account that has been given access to a team app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "title": "Heroku Platform API - Team App Collaborator",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/collaborator/definitions/email"
+            }
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new collaborator on a team app. Use this endpoint instead of the `/apps/{app_id_or_name}/collaborator` endpoint when you want the collaborator to be granted [permissions] (https://devcenter.heroku.com/articles/org-users-access#roles-and-app-permissions) according to their role in the team.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/collaborators",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/team-app-permission/definitions/name"
+                },
+                "description": "An array of permissions to give to the collaborator."
+              },
+              "silent": {
+                "$ref": "#/definitions/collaborator/definitions/silent"
+              },
+              "user": {
+                "$ref": "#/definitions/account/definitions/identity"
+              }
+            },
+            "required": [
+              "user"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing collaborator from a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for a collaborator on a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update an existing collaborator from a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/team-app-permission/definitions/name"
+                },
+                "description": "An array of permissions to give to the collaborator."
+              }
+            },
+            "required": [
+              "permissions"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List collaborators on a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app-collaborator"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app collaborator belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/collaborator/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/collaborator/definitions/id"
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/collaborator/definitions/updated_at"
+        },
+        "user": {
+          "description": "identity of collaborated account",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-app-permission": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A team app permission is a behavior that is assigned to a user in a team app.",
+      "stability": "prototype",
+      "title": "Heroku Platform API - Team App Permission",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-app-permission/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "The name of the app permission.",
+          "example": "view",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "A description of what the app permission allows.",
+          "example": "Can manage config, deploy, run commands and restart the app.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Lists permissions available to teams.",
+          "href": "/teams/permissions",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app-permission"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/team-app-permission/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/team-app-permission/definitions/description"
+        }
+      }
+    },
+    "team-app": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An team app encapsulates the team specific functionality of Heroku apps.",
+      "stability": "development",
+      "title": "Heroku Platform API - Team App",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "locked": {
+          "default": false,
+          "description": "are other team members forbidden from joining this app.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          ]
+        },
+        "joined": {
+          "default": false,
+          "description": "is the current member a collaborator on this app.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "personal": {
+          "default": false,
+          "description": "force creation of the app in the user account even if a default team is set.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new app in the specified team, in the default team if unspecified, or in personal account, if default team is not set.",
+          "href": "/teams/apps",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "locked": {
+                "$ref": "#/definitions/team-app/definitions/locked"
+              },
+              "name": {
+                "$ref": "#/definitions/app/definitions/name"
+              },
+              "team": {
+                "$ref": "#/definitions/team/definitions/name"
+              },
+              "personal": {
+                "$ref": "#/definitions/team-app/definitions/personal"
+              },
+              "region": {
+                "$ref": "#/definitions/region/definitions/name"
+              },
+              "space": {
+                "$ref": "#/definitions/space/definitions/name"
+              },
+              "stack": {
+                "$ref": "#/definitions/stack/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "List apps in the default team, or in personal account, if default team is not set.",
+          "href": "/teams/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "Lock or unlock a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "locked": {
+                "$ref": "#/definitions/team-app/definitions/locked"
+              }
+            },
+            "required": [
+              "locked"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app"
+          },
+          "title": "Update Locked"
+        },
+        {
+          "description": "Transfer an existing team app to another Heroku account.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "owner": {
+                "$ref": "#/definitions/account/definitions/identity"
+              }
+            },
+            "required": [
+              "owner"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Transfer to Account"
+        },
+        {
+          "description": "Transfer an existing team app to another team.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "owner": {
+                "$ref": "#/definitions/team/definitions/name"
+              }
+            },
+            "required": [
+              "owner"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app"
+          },
+          "title": "Transfer to Team"
+        },
+        {
+          "description": "List team apps.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        }
+      ],
+      "properties": {
+        "archived_at": {
+          "$ref": "#/definitions/app/definitions/archived_at"
+        },
+        "buildpack_provided_description": {
+          "$ref": "#/definitions/app/definitions/buildpack_provided_description"
+        },
+        "created_at": {
+          "$ref": "#/definitions/app/definitions/created_at"
+        },
+        "git_url": {
+          "$ref": "#/definitions/app/definitions/git_url"
+        },
+        "id": {
+          "$ref": "#/definitions/app/definitions/id"
+        },
+        "joined": {
+          "$ref": "#/definitions/team-app/definitions/joined"
+        },
+        "locked": {
+          "$ref": "#/definitions/team-app/definitions/locked"
+        },
+        "maintenance": {
+          "$ref": "#/definitions/app/definitions/maintenance"
+        },
+        "name": {
+          "$ref": "#/definitions/app/definitions/name"
+        },
+        "team": {
+          "description": "team that owns this app",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "owner": {
+          "description": "identity of app owner",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "region": {
+          "description": "identity of app region",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/region/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/region/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "released_at": {
+          "$ref": "#/definitions/app/definitions/released_at"
+        },
+        "repo_size": {
+          "$ref": "#/definitions/app/definitions/repo_size"
+        },
+        "slug_size": {
+          "$ref": "#/definitions/app/definitions/slug_size"
+        },
+        "space": {
+          "description": "identity of space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/space/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "stack": {
+          "description": "identity of app stack",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app/definitions/updated_at"
+        },
+        "web_url": {
+          "$ref": "#/definitions/app/definitions/web_url"
+        }
+      }
+    },
+    "team-feature": {
+      "description": "A team feature represents a feature enabled on a team account.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Feature",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when team feature was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of team feature",
+          "example": "Causes account to example.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "doc_url": {
+          "description": "documentation URL of team feature",
+          "example": "http://devcenter.heroku.com/articles/example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "enabled": {
+          "description": "whether or not team feature has been enabled",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of team feature",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-feature/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/team-feature/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of team feature",
+          "example": "name",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state of team feature",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when team feature was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for an existing team feature.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Fteam-feature%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-feature"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing team features.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/features",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-feature"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-feature/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/team-feature/definitions/description"
+        },
+        "doc_url": {
+          "$ref": "#/definitions/team-feature/definitions/doc_url"
+        },
+        "enabled": {
+          "$ref": "#/definitions/team-feature/definitions/enabled"
+        },
+        "id": {
+          "$ref": "#/definitions/team-feature/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/team-feature/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/team-feature/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/team-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/team-feature/definitions/feedback_email"
+        }
+      }
+    },
+    "team-invitation": {
+      "description": "A team invitation represents an invite to a team.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Invitation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when invitation was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-invitation/definitions/id"
+            }
+          ]
+        },
+        "id": {
+          "description": "unique identifier of an invitation",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "token": {
+          "description": "special token for invitation",
+          "example": "614ae25aa2d4802096cd7c18625b526c",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when invitation was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of a team's Identity Providers",
+          "title": "List",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/invitations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-invitation"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        },
+        {
+          "description": "Create Team Invitation",
+          "title": "Create",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invitations",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          }
+        },
+        {
+          "description": "Revoke a team invitation.",
+          "title": "Revoke",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "self"
+        },
+        {
+          "description": "Get an invitation by its token",
+          "title": "Get",
+          "href": "/teams/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Ftoken)}",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "$ref": "#/definitions/team-invitation"
+          }
+        },
+        {
+          "description": "Accept Team Invitation",
+          "title": "Accept",
+          "href": "/teams/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Ftoken)}/accept",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          }
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-invitation/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/team-invitation/definitions/id"
+        },
+        "invited_by": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "team": {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-invitation/definitions/updated_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-invoice": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A Team Invoice is an itemized bill of goods for a team which includes pricing and charges.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Invoice",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addons_total": {
+          "description": "total add-ons charges in on this invoice",
+          "example": 25000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "database_total": {
+          "description": "total database charges on this invoice",
+          "example": 25000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "charges_total": {
+          "description": "total charges on this invoice",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "created_at": {
+          "description": "when invoice was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credits_total": {
+          "description": "total credits on this invoice",
+          "example": 100000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dyno_units": {
+          "description": "total amount of dyno units consumed across dyno types.",
+          "example": 1.92,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this invoice",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-invoice/definitions/number"
+            }
+          ]
+        },
+        "number": {
+          "description": "human readable invoice number",
+          "example": 9403943,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "payment_status": {
+          "description": "status of the invoice payment",
+          "example": "Paid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "platform_total": {
+          "description": "total platform charges on this invoice",
+          "example": 50000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "period_end": {
+          "description": "the ending date that the invoice covers",
+          "example": "01/31/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "period_start": {
+          "description": "the starting date that this invoice covers",
+          "example": "01/01/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "payment status for this invoice (pending, successful, failed)",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "total": {
+          "description": "combined total of charges and credits on this invoice",
+          "example": 100000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "updated_at": {
+          "description": "when invoice was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "weighted_dyno_hours": {
+          "description": "The total amount of hours consumed across dyno types.",
+          "example": 1488,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing invoice.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invoices/{(%23%2Fdefinitions%2Fteam-invoice%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-invoice"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing invoices.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invoices",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-invoice"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "addons_total": {
+          "$ref": "#/definitions/team-invoice/definitions/addons_total"
+        },
+        "database_total": {
+          "$ref": "#/definitions/team-invoice/definitions/database_total"
+        },
+        "charges_total": {
+          "$ref": "#/definitions/team-invoice/definitions/charges_total"
+        },
+        "created_at": {
+          "$ref": "#/definitions/team-invoice/definitions/created_at"
+        },
+        "credits_total": {
+          "$ref": "#/definitions/team-invoice/definitions/credits_total"
+        },
+        "dyno_units": {
+          "$ref": "#/definitions/team-invoice/definitions/dyno_units"
+        },
+        "id": {
+          "$ref": "#/definitions/team-invoice/definitions/id"
+        },
+        "number": {
+          "$ref": "#/definitions/team-invoice/definitions/number"
+        },
+        "payment_status": {
+          "$ref": "#/definitions/team-invoice/definitions/payment_status"
+        },
+        "period_end": {
+          "$ref": "#/definitions/team-invoice/definitions/period_end"
+        },
+        "period_start": {
+          "$ref": "#/definitions/team-invoice/definitions/period_start"
+        },
+        "platform_total": {
+          "$ref": "#/definitions/team-invoice/definitions/platform_total"
+        },
+        "state": {
+          "$ref": "#/definitions/team-invoice/definitions/state"
+        },
+        "total": {
+          "$ref": "#/definitions/team-invoice/definitions/total"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-invoice/definitions/updated_at"
+        },
+        "weighted_dyno_hours": {
+          "$ref": "#/definitions/team-invoice/definitions/weighted_dyno_hours"
+        }
+      }
+    },
+    "team-member": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A team member is an individual with access to a team.",
+      "stability": "development",
+      "additionalProperties": false,
+      "required": [
+        "created_at",
+        "email",
+        "federated",
+        "updated_at"
+      ],
+      "title": "Heroku Platform API - Team Member",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the membership record was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "email": {
+          "description": "email address of the team member",
+          "example": "someone@example.org",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "federated": {
+          "description": "whether the user is federated and belongs to an Identity Provider",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of the team member",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-member/definitions/email"
+            },
+            {
+              "$ref": "#/definitions/team-member/definitions/id"
+            }
+          ]
+        },
+        "name": {
+          "description": "full name of the team member",
+          "example": "Tina Edmonds",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "two_factor_authentication": {
+          "description": "whether the Enterprise team member has two factor authentication enabled",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "updated_at": {
+          "description": "when the membership record was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new team member, or update their role.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "PUT",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Create or Update"
+        },
+        {
+          "description": "Create a new team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update a team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Remove a member from the team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Fteam-member%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "List members of the team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "GET",
+          "ranges": [
+            "email"
+          ],
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-member"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List the apps of a team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Fteam-member%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Member"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-member/definitions/created_at"
+        },
+        "email": {
+          "$ref": "#/definitions/team-member/definitions/email"
+        },
+        "federated": {
+          "$ref": "#/definitions/team-member/definitions/federated"
+        },
+        "id": {
+          "$ref": "#/definitions/team-member/definitions/id"
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "two_factor_authentication": {
+          "$ref": "#/definitions/team-member/definitions/two_factor_authentication"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-member/definitions/updated_at"
+        },
+        "user": {
+          "description": "user information for the membership",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-preferences": {
+      "description": "Tracks a Team's Preferences",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Preferences",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "default-permission": {
+          "description": "The default permission used when adding new members to the team",
+          "example": "member",
+          "readOnly": false,
+          "enum": [
+            "admin",
+            "member",
+            "viewer",
+            null
+          ],
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/team/definitions/identity"
+        },
+        "whitelisting-enabled": {
+          "description": "Whether whitelisting rules should be applied to add-on installations",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve Team Preferences",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-preferences"
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update Team Preferences",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "whitelisting-enabled": {
+                "$ref": "#/definitions/team-preferences/definitions/whitelisting-enabled"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-preferences"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "default-permission": {
+          "$ref": "#/definitions/team-preferences/definitions/default-permission"
+        },
+        "whitelisting-enabled": {
+          "$ref": "#/definitions/team-preferences/definitions/whitelisting-enabled"
+        }
+      }
+    },
+    "team": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Teams allow you to manage access to a shared group of applications and other resources.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the team was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credit_card_collections": {
+          "description": "whether charges incurred by the team are paid by credit card.",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "default": {
+          "description": "whether to use this team when none is specified",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of team",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team/definitions/name"
+            },
+            {
+              "$ref": "#/definitions/team/definitions/id"
+            }
+          ]
+        },
+        "address_1": {
+          "type": [
+            "string"
+          ],
+          "description": "street address line 1",
+          "example": "40 Hickory Lane"
+        },
+        "address_2": {
+          "type": [
+            "string"
+          ],
+          "description": "street address line 2",
+          "example": "Suite 103"
+        },
+        "card_number": {
+          "type": [
+            "string"
+          ],
+          "description": "encrypted card number of payment method",
+          "example": "encrypted-card-number"
+        },
+        "city": {
+          "type": [
+            "string"
+          ],
+          "description": "city",
+          "example": "San Francisco"
+        },
+        "country": {
+          "type": [
+            "string"
+          ],
+          "description": "country",
+          "example": "US"
+        },
+        "cvv": {
+          "type": [
+            "string"
+          ],
+          "description": "card verification value",
+          "example": "123"
+        },
+        "expiration_month": {
+          "type": [
+            "string"
+          ],
+          "description": "expiration month",
+          "example": "11"
+        },
+        "expiration_year": {
+          "type": [
+            "string"
+          ],
+          "description": "expiration year",
+          "example": "2014"
+        },
+        "first_name": {
+          "type": [
+            "string"
+          ],
+          "description": "the first name for payment method",
+          "example": "Jason"
+        },
+        "last_name": {
+          "type": [
+            "string"
+          ],
+          "description": "the last name for payment method",
+          "example": "Walker"
+        },
+        "other": {
+          "type": [
+            "string"
+          ],
+          "description": "metadata",
+          "example": "Additional information for payment method"
+        },
+        "postal_code": {
+          "type": [
+            "string"
+          ],
+          "description": "postal code",
+          "example": "90210"
+        },
+        "state": {
+          "type": [
+            "string"
+          ],
+          "description": "state",
+          "example": "CA"
+        },
+        "membership_limit": {
+          "description": "upper limit of members allowed in a team.",
+          "example": 25,
+          "readOnly": true,
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "unique name of team",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "provisioned_licenses": {
+          "description": "whether the team is provisioned licenses by salesforce.",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "role": {
+          "description": "role in the team",
+          "enum": [
+            "admin",
+            "collaborator",
+            "member",
+            "owner",
+            null
+          ],
+          "example": "admin",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "type": {
+          "description": "type of team.",
+          "example": "team",
+          "enum": [
+            "enterprise",
+            "team"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the team was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List teams in which you are a member.",
+          "href": "/teams",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for a team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "Update team properties.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "default": {
+                "$ref": "#/definitions/team/definitions/default"
+              },
+              "name": {
+                "$ref": "#/definitions/team/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Create a new team.",
+          "href": "/teams",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/team/definitions/name"
+              },
+              "address_1": {
+                "$ref": "#/definitions/team/definitions/address_1"
+              },
+              "address_2": {
+                "$ref": "#/definitions/team/definitions/address_2"
+              },
+              "card_number": {
+                "$ref": "#/definitions/team/definitions/card_number"
+              },
+              "city": {
+                "$ref": "#/definitions/team/definitions/city"
+              },
+              "country": {
+                "$ref": "#/definitions/team/definitions/country"
+              },
+              "cvv": {
+                "$ref": "#/definitions/team/definitions/cvv"
+              },
+              "expiration_month": {
+                "$ref": "#/definitions/team/definitions/expiration_month"
+              },
+              "expiration_year": {
+                "$ref": "#/definitions/team/definitions/expiration_year"
+              },
+              "first_name": {
+                "$ref": "#/definitions/team/definitions/first_name"
+              },
+              "last_name": {
+                "$ref": "#/definitions/team/definitions/last_name"
+              },
+              "other": {
+                "$ref": "#/definitions/team/definitions/other"
+              },
+              "postal_code": {
+                "$ref": "#/definitions/team/definitions/postal_code"
+              },
+              "state": {
+                "$ref": "#/definitions/team/definitions/state"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Delete"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/team/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/team/definitions/created_at"
+        },
+        "credit_card_collections": {
+          "$ref": "#/definitions/team/definitions/credit_card_collections"
+        },
+        "default": {
+          "$ref": "#/definitions/team/definitions/default"
+        },
+        "membership_limit": {
+          "$ref": "#/definitions/team/definitions/membership_limit"
+        },
+        "name": {
+          "$ref": "#/definitions/team/definitions/name"
+        },
+        "provisioned_licenses": {
+          "$ref": "#/definitions/team/definitions/provisioned_licenses"
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "type": {
+          "$ref": "#/definitions/team/definitions/type"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team/definitions/updated_at"
+        }
+      }
+    },
     "user-preferences": {
       "description": "Tracks a user's preferences and message dismissals",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -12216,7 +14265,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Organization"
         },
         {
           "description": "Whitelist an Add-on Service",
@@ -12245,7 +14294,7 @@
               "array"
             ]
           },
-          "title": "Create"
+          "title": "Create By Organization"
         },
         {
           "description": "Remove a whitelisted entity",
@@ -12255,7 +14304,61 @@
           "targetSchema": {
             "$ref": "#/definitions/whitelisted-add-on-service"
           },
-          "title": "Delete"
+          "title": "Delete By Organization"
+        },
+        {
+          "description": "List all whitelisted Add-on Services for a Team",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/whitelisted-addon-services",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/whitelisted-add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        },
+        {
+          "description": "Whitelist an Add-on Service",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/whitelisted-addon-services",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "addon_service": {
+                "description": "name of the Add-on to whitelist",
+                "example": "heroku-postgresql",
+                "type": [
+                  "string"
+                ]
+              }
+            }
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/whitelisted-add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Create By Team"
+        },
+        {
+          "description": "Remove a whitelisted entity",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/whitelisted-addon-services/{(%23%2Fdefinitions%2Fwhitelisted-add-on-service%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/whitelisted-add-on-service"
+          },
+          "title": "Delete By Team"
         }
       ],
       "properties": {
@@ -12478,6 +14581,33 @@
     },
     "stack": {
       "$ref": "#/definitions/stack"
+    },
+    "team-app-collaborator": {
+      "$ref": "#/definitions/team-app-collaborator"
+    },
+    "team-app-permission": {
+      "$ref": "#/definitions/team-app-permission"
+    },
+    "team-app": {
+      "$ref": "#/definitions/team-app"
+    },
+    "team-feature": {
+      "$ref": "#/definitions/team-feature"
+    },
+    "team-invitation": {
+      "$ref": "#/definitions/team-invitation"
+    },
+    "team-invoice": {
+      "$ref": "#/definitions/team-invoice"
+    },
+    "team-member": {
+      "$ref": "#/definitions/team-member"
+    },
+    "team-preferences": {
+      "$ref": "#/definitions/team-preferences"
+    },
+    "team": {
+      "$ref": "#/definitions/team"
     },
     "user-preferences": {
       "$ref": "#/definitions/user-preferences"


### PR DESCRIPTION
This change updates to the latest Heroku API schema, fixing duplicate/outdated link titles. This caused Schematics to drop methods in the case of duplicates. We also took this opportunity to sanity check all of the existing Link titles (and resulting method names), given we were already going to break backwards compatibility.  It's probable that upgrading to this version will break code for existing users of the pkg, as many method names have been changed/updated.

Given the above, I think we should document the change in either a changelog entry, in the README, or just by doing a major version bump.