### PR TITLE
Update to the latest API schema.

### DIFF
--- a/v3/schema.json
+++ b/v3/schema.json
@@ -800,21 +800,6 @@
                 }
               },
               "strictProperties": true
-            },
-            "plan": {
-              "description": "identity of add-on plan",
-              "properties": {
-                "id": {
-                  "$ref": "#/definitions/plan/definitions/id"
-                },
-                "name": {
-                  "$ref": "#/definitions/plan/definitions/name"
-                }
-              },
-              "strictProperties": true,
-              "type": [
-                "object"
-              ]
             }
           },
           "additionalProperties": false,
@@ -1904,6 +1889,9 @@
           "properties": {
             "cents": {
               "$ref": "#/definitions/plan/definitions/cents"
+            },
+            "contract": {
+              "$ref": "#/definitions/plan/definitions/contract"
             },
             "unit": {
               "$ref": "#/definitions/plan/definitions/unit"
@@ -9839,6 +9827,213 @@
         }
       }
     },
+    "peering-info": {
+      "description": "[Peering Info](https://devcenter.heroku.com/articles/private-space-vpc-peering) gives you the information necessary to peer an AWS VPC to a Private Space.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Peering Info",
+      "type": [
+        "object"
+      ],
+      "properties": {
+        "aws_account_id": {
+          "$ref": "#/definitions/peering/definitions/aws_account_id"
+        },
+        "aws_region": {
+          "$ref": "#/definitions/region/definitions/provider/properties/region"
+        },
+        "vpc_id": {
+          "$ref": "#/definitions/peering/definitions/vpc_id"
+        },
+        "vpc_cidr": {
+          "description": "The CIDR range of the Private Space VPC",
+          "$ref": "#/definitions/peering/definitions/cidr"
+        },
+        "dyno_cidr_blocks": {
+          "description": "The CIDR ranges that should be routed to the Private Space VPC.",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/peering/definitions/cidr"
+          }
+        },
+        "unavailable_cidr_blocks": {
+          "description": "The CIDR ranges that you must not conflict with.",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/peering/definitions/cidr"
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Provides the necessary information to establish an AWS VPC Peering with your private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peering-info",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/peering-info"
+          },
+          "title": "Info"
+        }
+      ]
+    },
+    "peering": {
+      "description": "[Peering](https://devcenter.heroku.com/articles/private-space-vpc-peering) provides a way to peer your Private Space VPC to another AWS VPC.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Peering",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "aws_account_id": {
+          "description": "The AWS account ID of your Private Space.",
+          "example": "123456789012",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "vpc_id": {
+          "description": "The AWS VPC ID of the peer.",
+          "example": "vpc-1234567890",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The type of peering connection.",
+          "example": "heroku-managed",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "heroku-managed",
+            "customer-managed",
+            "unknown"
+          ]
+        },
+        "status": {
+          "description": "The status of the peering connection.",
+          "example": "pending-acceptance",
+          "enum": [
+            "initiating-request",
+            "pending-acceptance",
+            "provisioning",
+            "active",
+            "failed",
+            "expired",
+            "rejected",
+            "deleted"
+          ],
+          "type": [
+            "string"
+          ],
+          "readOnly": true
+        },
+        "pcx_id": {
+          "description": "The AWS VPC Peering Connection ID of the peering.",
+          "example": "pcx-123456789012",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "cidr": {
+          "description": "An IP address and the number of significant bits that make up the routing or networking portion.",
+          "example": "10.0.0.0/16",
+          "type": [
+            "string"
+          ]
+        },
+        "expires": {
+          "description": "When a peering connection will expire.",
+          "example": "2020-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/peering/definitions/type"
+        },
+        "pcx_id": {
+          "$ref": "#/definitions/peering/definitions/pcx_id"
+        },
+        "cidr_blocks": {
+          "description": "The CIDR blocks of the peer.",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/peering/definitions/cidr"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/peering/definitions/status"
+        },
+        "aws_vpc_id": {
+          "$ref": "#/definitions/peering/definitions/vpc_id"
+        },
+        "aws_account_id": {
+          "$ref": "#/definitions/peering/definitions/aws_account_id"
+        },
+        "expires": {
+          "$ref": "#/definitions/peering/definitions/expires"
+        }
+      },
+      "links": [
+        {
+          "description": "List peering connections of a private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peerings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/peering"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Accept a pending peering connection with a private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peerings/{(%23%2Fdefinitions%2Fpeering%2Fdefinitions%2Fpcx_id)}/actions/accept",
+          "method": "POST",
+          "rel": "empty",
+          "title": "Accept"
+        },
+        {
+          "description": "Destroy an active peering connection with a private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peerings/{(%23%2Fdefinitions%2Fpeering%2Fdefinitions%2Fpcx_id)}",
+          "rel": "empty",
+          "method": "DELETE",
+          "title": "Destroy"
+        },
+        {
+          "description": "Fetch information for existing peering connection",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peerings/{(%23%2Fdefinitions%2Fpeering%2Fdefinitions%2Fpcx_id)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/peering"
+          },
+          "title": "Info"
+        }
+      ]
+    },
     "organization-app-permission": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "description": "Deprecated: An organization app permission is a behavior that is assigned to a user in an organization app.",
@@ -10696,6 +10891,14 @@
             "integer"
           ]
         },
+        "contract": {
+          "description": "price is negotiated in a contract outside of monthly add-on billing",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "unit": {
           "description": "unit of price for plan",
           "example": "month",
@@ -10823,6 +11026,9 @@
           "properties": {
             "cents": {
               "$ref": "#/definitions/plan/definitions/cents"
+            },
+            "contract": {
+              "$ref": "#/definitions/plan/definitions/contract"
             },
             "unit": {
               "$ref": "#/definitions/plan/definitions/unit"
@@ -10984,6 +11190,19 @@
               "readOnly": true,
               "type": [
                 "string"
+              ],
+              "enum": [
+                "ap-south-1",
+                "eu-west-1",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "eu-central-1",
+                "ap-northeast-2",
+                "ap-northeast-1",
+                "us-east-1",
+                "sa-east-1",
+                "us-west-1",
+                "us-west-2"
               ]
             }
           },
@@ -15060,6 +15279,12 @@
     },
     "password-reset": {
       "$ref": "#/definitions/password-reset"
+    },
+    "peering-info": {
+      "$ref": "#/definitions/peering-info"
+    },
+    "peering": {
+      "$ref": "#/definitions/peering"
     },
     "organization-app-permission": {
       "$ref": "#/definitions/organization-app-permission"


### PR DESCRIPTION
We're in need of the peering information in Terraform. https://github.com/terraform-providers/terraform-provider-heroku/pull/57 adds support to the Heroku provider. This in turn can be used to automate the configuration of peering connections with AWS VPCs.