### PR TITLE
Use go log instead of stderr for debug outputting

### DIFF
--- a/v3/transport.go
+++ b/v3/transport.go
@@ -79,7 +79,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			log.Println(err)
 		} else {
-			log.Printf("%s", string(dump[:]))
+			log.Printf("%s", dump)
 		}
 	}
 
@@ -96,7 +96,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			log.Println(err)
 		} else {
-			log.Printf("%s", string(dump[:]))
+			log.Printf("%s", dump)
 		}
 	}
 

--- a/v3/transport.go
+++ b/v3/transport.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	"strings"
 
 	"github.com/pborman/uuid"
@@ -80,8 +79,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			log.Println(err)
 		} else {
-			os.Stderr.Write(dump)
-			os.Stderr.Write([]byte{'\n', '\n'})
+			log.Printf("%s", string(dump[:]))
 		}
 	}
 
@@ -98,8 +96,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			log.Println(err)
 		} else {
-			os.Stderr.Write(dump)
-			os.Stderr.Write([]byte{'\n'})
+			log.Printf("%s", string(dump[:]))
 		}
 	}
 


### PR DESCRIPTION
Lets use Go `log` to output response and request debug dumps:

* Using `stderr` can be problematic for clients that close that stream (for example the Terraform provider framework)
* Typically I would expect `stderr` reserved for errors; response and request dumps aren't errors
* Using go `log` is more flexible because this allows the user to [override the output](https://golang.org/pkg/log/#SetOutput) (which is what the Terraform provider framework does)
