### PR TITLE
Update API schema to support Pipeline Promotions with Release ID

### DIFF
--- a/v6/heroku.go
+++ b/v6/heroku.go
@@ -3502,6 +3502,10 @@ type PipelinePromotionCreateOpts struct {
 		App *struct {
 			ID *string `json:"id,omitempty" url:"id,omitempty,key"` // unique identifier of app
 		} `json:"app,omitempty" url:"app,omitempty,key"` // the app which was promoted from
+		Release *struct {
+			ID *string `json:"id,omitempty" url:"id,omitempty,key"` // unique identifier of release
+		} `json:"release,omitempty" url:"release,omitempty,key"` // the specific release to promote from (optional, defaults to current
+		// release)
 	} `json:"source" url:"source,key"` // the app being promoted from
 	Targets []struct {
 		App *struct {

--- a/v6/schema.json
+++ b/v6/schema.json
@@ -11283,6 +11283,18 @@
                     "type": [
                       "object"
                     ]
+                  },
+                  "release": {
+                    "description": "the specific release to promote from (optional, defaults to current release)",
+                    "properties": {
+                      "id": {
+                        "$ref": "#/definitions/release/definitions/id"
+                      }
+                    },
+                    "strictProperties": true,
+                    "type": [
+                      "object"
+                    ]
                   }
                 },
                 "type": [
@@ -12471,7 +12483,8 @@
           "enum": [
             "failed",
             "pending",
-            "succeeded"
+            "succeeded",
+            "expired"
           ],
           "example": "succeeded",
           "readOnly": true,


### PR DESCRIPTION
Dependency for Terraform Provider implementation https://github.com/heroku/terraform-provider-heroku/pull/410

Generated by running `make generate` (see [README](https://github.com/heroku/heroku-go?tab=readme-ov-file#update-client-for-schema)), which reflects [this new API attribute](https://devcenter.heroku.com/changelog-items/3408?preview=1).